### PR TITLE
Add Security Considerations section on Versioning Cryptography Suites.

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,15 @@
               ],
               status: "Internet-Draft",
               publisher: "IETF"
+            },
+            "VC-EXTENSION-REGISTRY": {
+              title: "Verifiable Credentials Extension Registry",
+              href: "https://w3c-ccg.github.io/vc-extension-registry/",
+              authors: [
+                "Manu Sporny"
+              ],
+              status: "CG-DRAFT",
+              publisher: "Credentials Community Group"
             }
           },
           postProcess: [restrictRefs]
@@ -1767,6 +1776,72 @@ software.
 
 <div class="issue">TODO: We need to add a complete list of security
 considerations.</div>
+
+      <section>
+        <h3>Versioning Cryptography Suites</h3>
+
+        <p>
+Cryptography protects information in a way that requires knowledge of a secret
+to access the information (computationally easy), or a concerted
+brute-force attack to access the same information without the secret
+(computationally difficult). All modern cryptography requires the
+computationally difficult approach to remain difficult throughout time, which
+does not always hold due to breakthroughs in science and mathematics. That is
+to say that <em>Cryptography has a shelf life</em>.
+        </p>
+        <p>
+This specification plans for the obsolecense of all cryptographic approaches by
+asserting that whatever cryptography is in use today is highly likely to be
+broken over time. Given this assumption, it makes sense to identify
+cryptographic suites in a way where we can differentiate different versions
+throughout time. When versioning cryptographic suites, there are several
+approaches that can be taken which include: parameters, numbers, and dates.
+        </p>
+        <p>
+Parametric versioning specifies the particular cryptographic parameters that are
+employed in a cryptographic suite. For example, one could use an identifier such
+as `RSAASSA-PKCS1-v1_5-SHA1`. The benefit to this scheme is that a well-trained
+cryptographer will be able to determine all of the parameters in play by the
+identifier. The drawback to this scheme is that most of the population that uses
+these sorts of identifiers are not well trained and thus will not understand
+that the previously mentioned identifier is a cryptographic suite that is no
+longer safe to use.
+        </p>
+        <p>
+Numbered versioning might specify a major and minor version number such as
+`1.0` or `2.1`. Numbered versioning conveys a specific order and suggests that
+higher version numbers are more capable than lower version numbers. The benefit
+of this approach is that it removes complex parameters that less expert
+developers might not understand with a simpler model that conveys that an
+upgrade might be appropriate. The drawback of this approach is that its not
+clear if an upgrade is necessary, as software version number increases often
+don't require an upgrade for the software to continue functioning. This can
+lead to developers thinking their usage of a particular version is safe, when
+it is not.
+        </p>
+        <p>
+Date-based versioning specifies a particular release date for a specific
+cryptographic suite. The benefit of a date, such as a year, is that it is
+immediately clear to a developer if the date is relatively old or new. Seeing
+an old date might prompt the developer to go searching for a newer
+cryptographic suite, where as a parametric or number-based versioning scheme
+might not. The downside of a date-based version is that some cryptographic
+suites might not expire for 5-10 years, prompting the developer to go
+searching for a newer cryptographic suite only to not find one that is newer.
+While this might be an inconvenience, it is one that results in safer
+ecosystem behaviour.
+        </p>
+        <p>
+It is highly encouraged that cryptographic suite identifiers are versioned
+using a year designation. For example, the cryptographic suite identifier
+`ecdsa-2022` implies that the suite is probably ok to use in the year 2025,
+but might not be a safe choice in the year 2042. A date-based versioning
+mechanism, however, is not enough by itself. All cryptographic suites that
+follow this specification are intended to be registered
+[[?VC-EXTENSION-REGISTRY]] in a way that clearly signal which cryptosuites
+are deprecated, standardized, or experimental.
+        </p>
+      </section>
 
       <section>
         <h3>Verification Method Binding</h3>

--- a/index.html
+++ b/index.html
@@ -1872,7 +1872,10 @@ COSE Algorithms Registry</a>, the
 JOSE Algorithms Registry</a>, and the latest
 <a href="https://csrc.nist.gov/publications/detail/fips/186/4/final">
 FIPS Digital Signature Standard
-</a> guidance.  Depending on your jurisdiction you may also need to consider additional guidance from <a href="https://www.etsi.org/deliver/etsi_ts/119300_119399/119312/01.02.01_60/ts_119312v010201p.pdf">ETSI</a> or other regulatory and standards bodies.
+</a> guidance.  Depending on your jurisdiction you may also need to consider
+additional guidance from
+<a href="https://www.etsi.org/deliver/etsi_ts/119300_119399/119312/01.02.01_60/ts_119312v010201p.pdf">ETSI</a>
+or other regional regulatory and standards bodies.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1859,6 +1859,21 @@ Use of experimental suites are expected to throw errors in implementations
 unless a `useExperimentalCryptosuites` option is used used specifying exactly
 the experimental cryptosuite to use.
         </p>
+
+        <p class="issue" title="Resolve VC Extension Registry Governance">
+The following text is debated due to the governance rules of the VC
+Extension Registry not being finalized:<br><br>
+Developers are urged to always refer to the [[?VC-EXTENSION-REGISTRY]] for
+the latest standardized cryptography suites as well as cross-checking their
+usage against, at least, the
+<a href="https://www.iana.org/assignments/cose/cose.xhtml#algorithms">
+COSE Algorithms Registry</a>, the
+<a href="https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms">
+JOSE Algorithms Registry</a>, and the latest
+<a href="https://csrc.nist.gov/publications/detail/fips/186/4/final">
+FIPS Digital Signature Standard
+</a> guidance.
+        </p>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -1842,15 +1842,22 @@ searching for a newer cryptographic suite only to not find one that is newer.
 While this might be an inconvenience, it is one that results in safer
 ecosystem behavior.
         </p>
-        <p>
+        <p class="issue" data-number="38">
+The following text is currently under debate:<br><br>
 It is highly encouraged that cryptographic suite identifiers are versioned
 using a year designation. For example, the cryptographic suite identifier
-`ecdsa-2022` implies that the suite is probably ok to use in the year 2025,
-but might not be a safe choice in the year 2042. A date-based versioning
-mechanism, however, is not enough by itself. All cryptographic suites that
-follow this specification are intended to be registered
+`ecdsa-2022` implies that the suite is probably an acceptable of ECDSA in the
+year 2025, but might not be a safe choice in the year 2042. A date-based
+versioning mechanism, however, is not enough by itself. All cryptographic
+suites that follow this specification are intended to be registered
 [[?VC-EXTENSION-REGISTRY]] in a way that clearly signal which cryptosuites
-are deprecated, standardized, or experimental.
+are deprecated, standardized, or experimental. Cryptosuite registration will
+follow CFRG, IETF, NIST, FIPS, and safecurves guidance. Use of deprecated suites
+are expected to throw errors in implementations unless a `useUnsafeCryptosuites`
+option is used specifying exactly the unsafe cryptosuite to use.
+Use of experimental suites are expected to throw errors in implementations
+unless a `useExperimentalCryptosuites` option is used used specifying exactly
+the experimental cryptosuite to use.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1807,10 +1807,14 @@ Parametric versioning specifies the particular cryptographic parameters that are
 employed in a cryptographic suite. For example, one could use an identifier such
 as `RSASSA-PKCS1-v1_5-SHA1`. The benefit to this scheme is that a well-trained
 cryptographer will be able to determine all of the parameters in play by the
-identifier. The drawback to this scheme is that most of the population that uses
-these sorts of identifiers are not well trained and thus will not understand
+identifier. The drawback to this scheme is that most of the population that
+uses these sorts of identifiers are not well trained and thus will not understand
 that the previously mentioned identifier is a cryptographic suite that is no
-longer safe to use.
+longer safe to use. Additionally, this lack of knowledge might lead software
+developers to generalize the parsing of cryptographic suite identifiers
+such that any combination of cryptographic primitives becomes acceptable,
+resulting in reduced security. Ideally, cryptographic suites are implemented
+in software as specific, acceptable profiles of cryptographic parameters instead.
         </p>
         <p>
 Numbered versioning might specify a major and minor version number such as

--- a/index.html
+++ b/index.html
@@ -1856,7 +1856,7 @@ follow CFRG, IETF, NIST, FIPS, and safecurves guidance. Use of deprecated suites
 are expected to throw errors in implementations unless a `useUnsafeCryptosuites`
 option is used specifying exactly the unsafe cryptosuite to use.
 Use of experimental suites are expected to throw errors in implementations
-unless a `useExperimentalCryptosuites` option is used used specifying exactly
+unless a `useExperimentalCryptosuites` option is used specifying exactly
 the experimental cryptosuite to use.
         </p>
 
@@ -1872,7 +1872,7 @@ COSE Algorithms Registry</a>, the
 JOSE Algorithms Registry</a>, and the latest
 <a href="https://csrc.nist.gov/publications/detail/fips/186/4/final">
 FIPS Digital Signature Standard
-</a> guidance.
+</a> guidance.  Depending on your jurisdiction you may also need to consider additional guidance from <a href="https://www.etsi.org/deliver/etsi_ts/119300_119399/119312/01.02.01_60/ts_119312v010201p.pdf">ETSI</a> or other regulatory and standards bodies.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1781,26 +1781,31 @@ considerations.</div>
         <h3>Versioning Cryptography Suites</h3>
 
         <p>
-Cryptography protects information in a way that requires knowledge of a secret
-to access the information (computationally easy), or a concerted
-brute-force attack to access the same information without the secret
-(computationally difficult). All modern cryptography requires the
+Cryptography secures information through the use of secrets. Knowledge of the
+necessary secret makes it computationally easy to access certain information. The
+same information can be accessed if a computationally-difficult, brute-force effort
+successfully guesses the secret. All modern cryptography requires the
 computationally difficult approach to remain difficult throughout time, which
 does not always hold due to breakthroughs in science and mathematics. That is
 to say that <em>Cryptography has a shelf life</em>.
         </p>
         <p>
-This specification plans for the obsolecense of all cryptographic approaches by
+This specification plans for the obsolescence of all cryptographic approaches by
 asserting that whatever cryptography is in use today is highly likely to be
-broken over time. Given this assumption, it makes sense to identify
-cryptographic suites in a way where we can differentiate different versions
-throughout time. When versioning cryptographic suites, there are several
-approaches that can be taken which include: parameters, numbers, and dates.
+broken over time. Software systems have to be able to change the cryptography
+in use over time in order to continue to secure information. Such changes might
+involve increasing required secret sizes or modifications to the cryptographic
+primitives used. However, some combinations of cryptographic parameters
+might actually reduce security. Given these assumptions, systems need to be able to
+distinguish different combinations of safe cryptographic parameters, also known
+as cryptographic suites, from one another. When identifying or versioning
+cryptographic suites, there are several approaches that can be taken which
+include: parameters, numbers, and dates.
         </p>
         <p>
 Parametric versioning specifies the particular cryptographic parameters that are
 employed in a cryptographic suite. For example, one could use an identifier such
-as `RSAASSA-PKCS1-v1_5-SHA1`. The benefit to this scheme is that a well-trained
+as `RSASSA-PKCS1-v1_5-SHA1`. The benefit to this scheme is that a well-trained
 cryptographer will be able to determine all of the parameters in play by the
 identifier. The drawback to this scheme is that most of the population that uses
 these sorts of identifiers are not well trained and thus will not understand
@@ -1817,7 +1822,9 @@ upgrade might be appropriate. The drawback of this approach is that its not
 clear if an upgrade is necessary, as software version number increases often
 don't require an upgrade for the software to continue functioning. This can
 lead to developers thinking their usage of a particular version is safe, when
-it is not.
+it is not. Ideally, additional signals would be given to developers that use
+cryptographic suites in their software that periodic reviews of those
+suites for continued security are required.
         </p>
         <p>
 Date-based versioning specifies a particular release date for a specific
@@ -1829,7 +1836,7 @@ might not. The downside of a date-based version is that some cryptographic
 suites might not expire for 5-10 years, prompting the developer to go
 searching for a newer cryptographic suite only to not find one that is newer.
 While this might be an inconvenience, it is one that results in safer
-ecosystem behaviour.
+ecosystem behavior.
         </p>
         <p>
 It is highly encouraged that cryptographic suite identifiers are versioned


### PR DESCRIPTION
This PR adds a security considerations section on versioning cryptographic suites and outlines some design rationale behind the date-identified suites that we currently have.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/36.html" title="Last updated on Aug 19, 2022, 7:46 PM UTC (b1319da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/36/3b27d11...b1319da.html" title="Last updated on Aug 19, 2022, 7:46 PM UTC (b1319da)">Diff</a>