### PR TITLE
Add section on cryptographic agility and cryptographic hardening.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1966,8 +1966,8 @@ appropriate override flags.
 
         <p>
 <dfn class="lint-ignore">Cryptographic agility</dfn> is a practice by which one designs
-<em>frequently connected</em> information security systems to <em>support</em>
-multiple cryptographic primitives and algorithms at the same time. The primary
+<em>frequently connected</em> information security systems to support
+<em>switching between multiple cryptographic primitives and/or algorithms</em>. The primary
 goal of cryptographic agility is to enable systems to rapidly adapt to new
 cryptographic primitives and algorithms without making disruptive changes to the
 systems' infrastructure. Thus, when a particular cryptographic primitive, such 
@@ -1978,19 +1978,19 @@ be reconfigured to use a newer primitive via a simple configuration file change.
 Cryptographic agility is most effective when the client and the server in
 the information security system are in regular contact. However, when the
 messages protected by a particular cryptographic algorithm are long-lived, as
-with Verifiable Credentials, and when the client (holder) might not be
+with Verifiable Credentials, and/or when the client (holder) might not be
 able to easily recontact the server (issuer), then cryptographic agility does
 not provide the desired protections.
         </p>
         <p>
 <dfn class="lint-ignore">Cryptographic hardening</dfn> is a practice where one
 designs <em>rarely connected</em> information security systems to
-<em>employ</em> multiple algorithms at the same
-time. The primary goal of cryptographic hardening is to enable systems to
-survive the failure or one or more cryptographic algorithms without entirely
+<em>employ multiple primitives and/or algorithms at the same
+time</em>. The primary goal of cryptographic hardening is to enable systems to
+survive the failure or one or more cryptographic algorithms or primitives without
 losing cryptographic protection on the payload. For example, digitally
-signing a single piece of information in parallel using RSA, ECDSA, and
-Falcon algorithms would provide a mechanism that could survive the failure of two of
+signing a single piece of information using RSA, ECDSA, and Falcon algorithms
+in parallel would provide a mechanism that could survive the failure of two of
 these three digital signature algorithms. When a particular cryptographic
 algorithm is compromised,
 such as RSA using 768-bit keys, systems can still utilize the non-compromised

--- a/index.html
+++ b/index.html
@@ -1962,6 +1962,48 @@ appropriate override flags.
       </section>
 
       <section>
+        <h3>Agility vs. Hardening</h3>
+
+        <p>
+Cryptographic agility is a practice where one designs
+<em>frequently connected</em> information security systems to <em>support</em>
+multiple cryptographic primitives and algorithms at the same time. The primary
+goal of cryptographic agility is to enable systems to rapidly adapt to new
+cryptographic primitives and algorithms without making disruptive changes to the
+systems' infrastructure. Thus, when a particular cryptographic primitive is
+determined to be no longer safe to use, such as the SHA-1 algorithm, systems can
+be reconfigured to use a newer primitive via a simple configuration file change.
+        </p>
+        <p>
+Cryptographic agility is often effective when both the client and the server in
+the information security system are in regular contact. However, when the
+messages protected by a particular cryptographic algorithm are long-lived, like
+they are in Verifiable Credentials, and when the client (holder) might not be
+able to easily recontact the server (issuer), then cryptographic agility does
+not provide the protections necessary.
+        </p>
+        <p>
+<dfn class="lint-ignore">Cryptographic hardening</dfn> is a practice where one
+designs <em>rarely connected</em> information security systems to
+<em>employ</em> multiple algorithms at the same
+time. For example, digitally signing a single piece of information in parallel
+using RSA, ECDSA, and Falcon would provide a mechanism that could survive the
+failure of two of three digital signature algorithms. The primary goal of
+cryptographic hardening is to enable systems to survive the failure or one or
+more cryptographic algorithms without entirely losing cryptographic protection
+on the payload. Thus, when a particular cryptographic algorithm is compromised,
+such as RSA using 768-bit keys, systems can still utilize the non-compromised
+cryptographic algorithms to continue to protect the information.
+        </p>
+        <p>
+This specification is designed to enable the use of cryptographic hardening on
+all protected information and implementers are urged to take advantage of
+this feature for signed content that might need to be protected for a year or
+more.
+        </p>
+      </section>
+
+      <section>
         <h3>Verification Method Binding</h3>
 
         <p class="issue">

--- a/index.html
+++ b/index.html
@@ -1962,7 +1962,7 @@ appropriate override flags.
       </section>
 
       <section>
-        <h3>Agility vs. Hardening</h3>
+        <h3>Agility and Hardening</h3>
 
         <p>
 Cryptographic agility is a practice where one designs

--- a/index.html
+++ b/index.html
@@ -1965,41 +1965,42 @@ appropriate override flags.
         <h3>Agility and Hardening</h3>
 
         <p>
-Cryptographic agility is a practice where one designs
+<dfn class="lint-ignore">Cryptographic agility</dfn> is a practice by which one designs
 <em>frequently connected</em> information security systems to <em>support</em>
 multiple cryptographic primitives and algorithms at the same time. The primary
 goal of cryptographic agility is to enable systems to rapidly adapt to new
 cryptographic primitives and algorithms without making disruptive changes to the
-systems' infrastructure. Thus, when a particular cryptographic primitive is
-determined to be no longer safe to use, such as the SHA-1 algorithm, systems can
+systems' infrastructure. Thus, when a particular cryptographic primitive, such 
+as the SHA-1 algorithm, is determined to be no longer safe to use, systems can
 be reconfigured to use a newer primitive via a simple configuration file change.
         </p>
         <p>
-Cryptographic agility is often effective when both the client and the server in
+Cryptographic agility is most effective when the client and the server in
 the information security system are in regular contact. However, when the
-messages protected by a particular cryptographic algorithm are long-lived, like
-they are in Verifiable Credentials, and when the client (holder) might not be
+messages protected by a particular cryptographic algorithm are long-lived, as
+with Verifiable Credentials, and when the client (holder) might not be
 able to easily recontact the server (issuer), then cryptographic agility does
-not provide the protections necessary.
+not provide the desired protections.
         </p>
         <p>
 <dfn class="lint-ignore">Cryptographic hardening</dfn> is a practice where one
 designs <em>rarely connected</em> information security systems to
 <em>employ</em> multiple algorithms at the same
-time. For example, digitally signing a single piece of information in parallel
-using RSA, ECDSA, and Falcon would provide a mechanism that could survive the
-failure of two of three digital signature algorithms. The primary goal of
-cryptographic hardening is to enable systems to survive the failure or one or
-more cryptographic algorithms without entirely losing cryptographic protection
-on the payload. Thus, when a particular cryptographic algorithm is compromised,
+time. The primary goal of cryptographic hardening is to enable systems to
+survive the failure or one or more cryptographic algorithms without entirely
+losing cryptographic protection on the payload. For example, digitally
+signing a single piece of information in parallel using RSA, ECDSA, and
+Falcon algorithms would provide a mechanism that could survive the failure of two of
+these three digital signature algorithms. When a particular cryptographic
+algorithm is compromised,
 such as RSA using 768-bit keys, systems can still utilize the non-compromised
 cryptographic algorithms to continue to protect the information.
         </p>
         <p>
 This specification is designed to enable the use of cryptographic hardening on
-all protected information and implementers are urged to take advantage of
-this feature for signed content that might need to be protected for a year or
-more.
+all protected information. Implementers are urged to take advantage of this
+feature for all signed content that might need to be protected for a year or
+longer.
         </p>
       </section>
 


### PR DESCRIPTION
This PR adds a section on the differences between cryptographic agility and cryptographic hardening.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/41.html" title="Last updated on Aug 27, 2022, 7:20 PM UTC (d7ce189)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/41/034cb5c...d7ce189.html" title="Last updated on Aug 27, 2022, 7:20 PM UTC (d7ce189)">Diff</a>