### PR TITLE
Remove `suites` namespace from Multikey context url.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1131,7 +1131,7 @@ To encode a Multikey, the <a>verification method</a> `type` MUST be set to
             <pre class="example nohighlight"
               title="Multikey encoding of a Ed25519 public key">
 {
-  "@context": ["https://w3id.org/security/suites/multikey/v1"],
+  "@context": ["https://w3id.org/security/multikey/v1"],
   "id": "did:example:123456789abcdefghi#keys-1",
   "type": "Multikey",
   "controller": "did:example:123456789abcdefghi",


### PR DESCRIPTION
The multikey context is exclusively for the multikey key format and not a suite.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gannan08/vc-data-integrity/pull/49.html" title="Last updated on Sep 6, 2022, 6:33 PM UTC (582ed39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/49/9eddbc8...gannan08:582ed39.html" title="Last updated on Sep 6, 2022, 6:33 PM UTC (582ed39)">Diff</a>