### PR TITLE
fix `schema.org#` to `schema.org/` in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@ Similarly, a proof can be added to a JSON-LD data document like the following:
 
         <pre class="example highlight" title="A simple JSON-LD data document">
   {
-    "@context": {"title": "https://schema.org#title"},
+    "@context": {"title": "https://schema.org/title"},
     "title": "Hello world!"
   };
         </pre>
@@ -522,7 +522,7 @@ by adding the parameters outlined in this section:
         title="A simple signed JSON-LD data document">
   {
     "@context": [
-      {"title": "https://schema.org#title"},
+      {"title": "https://schema.org/title"},
       "https://w3id.org/security/suites/ed25519-2020/v1"
     ],
     "title": "Hello world!",
@@ -620,7 +620,7 @@ with the <code>proof</code> key in a document.
         <pre class="example highlight" title="A proof set in a data document">
 {
   "@context": [
-    {"title": "https://schema.org#title"},
+    {"title": "https://schema.org/title"},
     "https://w3id.org/security/suites/ed25519-2020/v1"
 ],
   "title": "Hello world!",
@@ -659,7 +659,7 @@ represented by associating an ordered list of proofs with the
         <pre class="example highlight" title="A proof chain in a data document">
 {
   "@context": [
-    {"title": "https://schema.org#title"},
+    {"title": "https://schema.org/title"},
     "https://w3id.org/security/suites/ed25519-2020/v1"
 ],
   "title": "Hello world!",
@@ -745,7 +745,7 @@ A signature can be added to a data document like the following:
 
         <pre class="example highlight" title="A simple data document">
 {
-  "@context": {"title": "https://schema.org#title"},
+  "@context": {"title": "https://schema.org/title"},
   "title": "Hello world!",
 }
         </pre>
@@ -757,7 +757,7 @@ by adding the parameters outlined in this section:
         <pre class="example highlight" title="A simple signed data document">
 {
   "@context": [
-    {"title": "https://schema.org#title"},
+    {"title": "https://schema.org/title"},
     "https://w3id.org/security/suites/ed25519-2020/v1"
 ],
   "title": "Hello world!",


### PR DESCRIPTION
fixes #50


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/vc-data-integrity/pull/54.html" title="Last updated on Sep 20, 2022, 3:02 PM UTC (e50a0f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/54/efd1ac6...TallTed:e50a0f0.html" title="Last updated on Sep 20, 2022, 3:02 PM UTC (e50a0f0)">Diff</a>