### PR TITLE
Fix link to zcap spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
             },
             "ZCAP": {
               title:    "Authorization Capabilities for Linked Data",
-              href:     "https://w3c-ccg.github.io/zcap-ld/",
+              href:     "https://w3c-ccg.github.io/zcap-spec",
               status:   "CGDRAFT",
               publisher:  "Credentials Community Group"
             },


### PR DESCRIPTION
Minor correction: fixes the link to the zcap spec.

Addresses: https://github.com/w3c-ccg/data-integrity-spec/issues/2


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/vc-data-integrity/pull/55.html" title="Last updated on Sep 23, 2022, 4:19 PM UTC (28cc533)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/55/84e4b28...aljones15:28cc533.html" title="Last updated on Sep 23, 2022, 4:19 PM UTC (28cc533)">Diff</a>