### PR TITLE
Add section on DataIntegrityProof.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1545,6 +1545,45 @@ the important role that cryptographic suite specifications play in ensuring
 data integrity.
       </p>
 
+      <section>
+        <h3>DataIntegrityProof</h3>
+
+        <p>
+A number of cryptographic suites follow a basic pattern when expressing a data
+integrity proof. This section specifies that general design pattern, a
+cryptographic suite type called a `DataIntegrityProof`, which reduces the burden
+of writing and implementing cryptographic suites through the reuse of design
+primitives and source code.
+        </p>
+
+        <p>
+When specifing a cryptographic suite that utilizes this design pattern, the
+`proof` value takes the following form:
+        </p>
+
+        <dl>
+          <dt>type</dt>
+          <dd>
+The `type` property MUST contain the string `DataIntegrityProof`.
+          </dd>
+          <dt>cryptosuite</dt>
+          <dd>
+The `cryptosuite` property MUST contain a string specifying the name of the
+cryptosuite.
+          </dd>
+          <dt>proofValue</dt>
+          <dd>
+The `proofValue` property MUST be used, as specified in <a href="#proofs"></a>.
+          </dd>
+        </dl>
+
+        <p>
+Cryptographic suite designers MUST use mandatory `proof` value properties
+defined in Section <a href="#proofs"></a>, and MAY define other properties
+specific to their cryptographic suite.
+        </p>
+      </section>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1549,8 +1549,8 @@ data integrity.
         <h3>DataIntegrityProof</h3>
 
         <p>
-A number of cryptographic suites follow a basic pattern when expressing a data
-integrity proof. This section specifies that general design pattern, a
+A number of cryptographic suites follow the same basic pattern when expressing a
+data integrity proof. This section specifies that general design pattern, a
 cryptographic suite type called a `DataIntegrityProof`, which reduces the burden
 of writing and implementing cryptographic suites through the reuse of design
 primitives and source code.


### PR DESCRIPTION
This PR adds a section on the `DataIntegrityProof` design pattern, which can be re-used for most of the cryptography suites we plan to standardize in the current VCWG.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/58.html" title="Last updated on Oct 9, 2022, 4:52 PM UTC (b78794d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/58/d04754c...b78794d.html" title="Last updated on Oct 9, 2022, 4:52 PM UTC (b78794d)">Diff</a>