### PR TITLE
Add initial JSON-LD Context for Data Integrity.

### DIFF
--- a/contexts/data-integrity/v1
+++ b/contexts/data-integrity/v1
@@ -1,0 +1,74 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@protected": true,
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "DataIntegrityProof": {
+      "@id": "https://w3id.org/security#DataIntegrityProof",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "cryptosuite": "https://w3id.org/security#cryptosuite",
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the JSON-LD Context for the Data Integrity specification, including the normative definition for `DataIntegrityProof` that is now contained in the specification. This change was proposed at W3C TPAC 2022 via this proposal and the PRs to add these concepts to the specification have achieved consensus over the past three weeks:

https://docs.google.com/presentation/d/16J9TcFc6fX18Cun_Rhj3xqNlnhkCs6MnPkGBlRL3YKg/edit

There is now an open source library that implements the latest specification including the context described in this PR (with a README explaining how to use it):

https://github.com/digitalbazaar/eddsa-2022-cryptosuite

There is also an initial draft of an interoperability test suite demonstrating the implementability of this PR (for the `eddsa-2022` cryptosuite):

https://w3c-ccg.github.io/di-eddsa-2022-test-suite/#conformance
