### PR TITLE
Update algorithm for Verify Proof

### DIFF
--- a/index.html
+++ b/index.html
@@ -1742,21 +1742,24 @@ the `proof` value removed.
 Let <var>transformedDocument</var> be the result of
 <a href="#dfn-transformation">transforming</a> the <var>unsecuredDocument</var>
 according to a <a>transformation algorithm</a> associated with the
-<var>cryptosuite</var> specified in <var>proof</var> and the <var>options</var>
-parameters provided as inputs to the algorithm.
+<a>cryptographic suite</a> specified in <var>proof</var> and the
+<var>options</var> parameters provided as inputs to the algorithm.
+The type of <a>cryptographic suite</a> is specified by the
+<var>proof.type</var> value and MAY be further described by
+<a>cryptographic suite</a>-specific properties expressed in <var>proof</var>.
         </li>
           <li>
 Let <var>hashData</var> be the result of
 <a href="#dfn-hashing">hashing</a> the <var>transformedDocument</var>
 according to a <a>hashing algorithm</a> associated with the
-<var>cryptosuite</var> specified in the <var>proof</var> and <var>options</var>
-parameters provided as inputs to the algorithm.
+<a>cryptographic suite</a> specified in the <var>proof</var> and
+<var>options</var> parameters provided as inputs to the algorithm.
           </li>
           <li>
 Let <var>isProofVerified</var> be the result of running the
-<a>proof verification algorithm</a> associated with the <var>cryptosuite</var>
-with the <var>hashData</var> and <var>options</var> parameters provided
-as inputs to the algorithm.
+<a>proof verification algorithm</a> associated with the
+<a>cryptographic suite</a> with the <var>hashData</var> and <var>options</var>
+parameters provided as inputs to the algorithm.
           </li>
           <li>
 If the <var>proof</var>.<var>proofPurpose</var> value does not match

--- a/index.html
+++ b/index.html
@@ -1739,16 +1739,16 @@ the `proof` value removed.
           </li>
           <li>
 Let <var>transformedDocument</var> be the result of
-<a href="#dfn-transformation">transforming</a> <var>unsecuredDocument</var>
+<a href="#dfn-transformation">transforming</a> the <var>unsecuredDocument</var>
 according to a <a>transformation algorithm</a> associated with the
 <var>cryptosuite</var> specified in <var>proof</var> and the <var>options</var>
 parameters provided as inputs to the algorithm.
         </li>
           <li>
 Let <var>hashData</var> be the result of
-<a href="#dfn-hashing">hashing</a> <var>transformedDocument</var>
+<a href="#dfn-hashing">hashing</a> the <var>transformedDocument</var>
 according to a <a>hashing algorithm</a> associated with the
-<var>cryptosuite</var> specified in <var>proof</var> and the <var>options</var>
+<var>cryptosuite</var> specified in the <var>proof</var> and <var>options</var>
 parameters provided as inputs to the algorithm.
           </li>
           <li>
@@ -1783,12 +1783,12 @@ Return <var>isProofValid</var> as the <a>verification result</a>.
 
         <p class="issue" title="Define how verification material is retrieved">
 Specify how <var>proof</var>.<var>verificationMethod</var> can be obtained,
-through some out-of-band process and passed in or it can be retrieved by
-derefencing its URL identifier, etc. It is expected that the <a>public key</a>
+e.g., through some out-of-band process, by
+dereferencing its URL identifier, etc. It is expected that the <a>public key</a>
 is retrieved by dereferencing its URL identifier in the <code>proof</code> node
 of the default graph of <var>securedDocument</var>. The algorithm needs to
-confirm that the <a>verification method</a> that describes cryptographic
-material, such as the <a>public key</a>, specifies its <a>controller</a> and
+confirm that the <a>verification method</a> that describes the cryptographic
+material, such as the <a>public key</a>, specifies its <a>controller</a>, and
 that its controllers's URL identifier can be dereferenced to reveal a
 bi-directional link back to the key. Ensure that the key's controller is a
 trusted entity before proceeding to the next step.

--- a/index.html
+++ b/index.html
@@ -1735,6 +1735,11 @@ is not set, a `MALFORMED_PROOF_ERROR`
 MUST be raised.
           </li>
           <li>
+If the <var>proof</var>.<var>proofPurpose</var> value does not match
+<var>options</var>.<var>expectedProofPurpose</var>, a
+`MISMATCHED_PROOF_PURPOSE_ERROR` MUST be raised.
+          </li>
+          <li>
 Let <var>unsecuredDocument</var> be a copy of <var>securedDocument</var> with
 the `proof` value removed.
           </li>
@@ -1760,11 +1765,6 @@ Let <var>isProofVerified</var> be the result of running the
 <a>proof verification algorithm</a> associated with the
 <a>cryptographic suite</a> with the <var>hashData</var> and <var>options</var>
 parameters provided as inputs to the algorithm.
-          </li>
-          <li>
-If the <var>proof</var>.<var>proofPurpose</var> value does not match
-<var>options</var>.<var>proofPurpose</var>, a `MISMATCHED_PROOF_PURPOSE_ERROR`
-MUST be raised.
           </li>
           <li>
 If the <var>proof</var>.<var>created</var> is set and it deviates more than

--- a/index.html
+++ b/index.html
@@ -1753,7 +1753,7 @@ according to a <a>hashing algorithm</a> associated with the
 parameters provided as inputs to the algorithm.
           </li>
           <li>
-Let <var>isProofValid</var> be the result of running the
+Let <var>isProofVerified</var> be the result of running the
 <a>proof verification algorithm</a> associated with the <var>cryptosuite</var>
 with the <var>hashData</var> and <var>options</var> parameters provided
 as inputs to the algorithm.
@@ -1778,7 +1778,7 @@ If <var>options</var>.<var>challenge</var> is set and it does not match
 raised.
           </li>
           <li>
-Return <var>isProofValid</var> as the <a>verification result</a>.
+Return <var>isProofVerified</var> as the <a>verification result</a>.
           </li>
         </ol>
 

--- a/index.html
+++ b/index.html
@@ -1729,8 +1729,8 @@ If the <var>proof</var>.<var>type</var>,
 `MALFORMED_PROOF_ERROR` MUST be raised.
           </li>
           <li>
-If the cryptographic suite requires the 
-<var>proof</var>.<var>created</var> value, and it 
+If the cryptographic suite requires the
+<var>proof</var>.<var>created</var> value, and it
 is not set, a `MALFORMED_PROOF_ERROR`
 MUST be raised.
           </li>

--- a/index.html
+++ b/index.html
@@ -1635,12 +1635,13 @@ to verify the authenticity and integrity of an
 <dfn>unsecured data document</dfn>. Required inputs are an
 <a>unsecured data document</a> (<var>unsecuredDocument</var>) and
 <a>proof options</a> (<var>options</var>). The
-<a>proof options</a> MUST contain an identifier for the
-<a>cryptographic suite</a> (<var>cryptosuite</var>); an identifier for the
+<a>proof options</a> MUST contain a type identifier for the
+<a>cryptographic suite</a> (<var>type</var>) and any other properties needed by
+the <a>cryptographic suite</a> type; an identifier for the
 <a>verification method</a> (<var>verificationMethod</var>) that can be used to
-verify the authenticity of the proof; and an [[!XMLSCHEMA11-2]] combined date and
-time string (<var>created</var>) containing the current date and time, accurate
-to at least one second, in Universal Time Code format. A
+verify the authenticity of the proof; and an [[!XMLSCHEMA11-2]] combined date
+and time string (<var>created</var>) containing the current date and time,
+accurate to at least one second, in Universal Time Code format. A
 <a href="#dfn-domain">security domain</a> (<var>domain</var>) and
 receiver-supplied challenge (<var>challenge</var>) might also be specified in
 the <var>options</var>. A <dfn>secured data document</dfn> is produced as
@@ -1650,44 +1651,49 @@ output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
         <ol class="algorithm">
           <li>
 Let <var>output</var> be a copy of <var>unsecuredDocument</var>.
-        </li>
+          </li>
           <li>
 Let <var>transformedDocument</var> be the result of
 <a href="#dfn-transformation">transforming</a> <var>unsecuredDocument</var>
 according to a <a>transformation algorithm</a> associated with the
-<var>cryptosuite</var> value and the <var>options</var> parameters provided
+<a>cryptographic suite</a> and the <var>options</var> parameters provided
 as inputs to the algorithm.
-        </li>
+          </li>
           <li>
 Let <var>hashData</var> be the result of
 <a href="#dfn-hashing">hashing</a> the <var>transformedDocument</var>
 according to a <a>hashing algorithm</a> associated with the
-<var>cryptosuite</var> value and the <var>options</var> parameters provided
-as inputs to the algorithm.
+<a>cryptographic suite</a> and the <var>options</var> parameters provided as
+inputs to the algorithm.
           </li>
           <li>
 Let <var>proof</var> be the result of running the
-<a>proof generation algorithm</a> associated with the <var>cryptosuite</var>
-with the <var>hashData</var> and </var><var>options</var> parameters provided
+<a>proof generation algorithm</a> associated with the <a>cryptographic suite</a>
+with the <var>hashData</var> and <var>options</var> parameters provided
 as inputs to the algorithm.
           </li>
           <li>
-If the <var>type</var>, <var>verificationMethod</var>,
-or <var>proofPurpose</var> values are not set in <var>proof</var>, a
+If the <var>proof</var>.<var>type</var>,
+<var>proof</var>.<var>verificationMethod</var>,
+or <var>proof</var>.<var>proofPurpose</var> values are not set, a
 `PROOF_GENERATION_ERROR` MUST be raised.
           </li>
           <li>
-If the cryptographic suite does not support unlinkability and the
-<var>created</var> value is not set in <var>proof</var>, a
+If the <a>cryptographic suite</a> requires the use of a created timestamp,
+and the <var>proof</var>.<var>created</var> value is not set, a
 `PROOF_GENERATION_ERROR` MUST be raised.
           </li>
           <li>
-If the <var>domain</var> and/or <var>challenge</var> values were set in
-<var>options</var> but are not set in <var>proof</var>, a
-`PROOF_GENERATION_ERROR` MUST be raised.
+If <var>options</var>.<var>domain</var> is set, it MUST be equal to
+<var>proof</var>.<var>domain</var> or a `PROOF_GENERATION_ERROR` MUST be raised.
           </li>
           <li>
-Set the `proof` property of <var>output</var> to the value of <var>proof</var>.
+If <var>options</var>.<var>challenge</var> is set, it MUST be equal to
+<var>proof</var>.<var>challenge</var> or a `PROOF_GENERATION_ERROR` MUST be
+raised.
+          </li>
+          <li>
+Set <var>output</var>.<var>proof</var> to the value of <var>proof</var>.
           </li>
           <li>
 Return <var>output</var> as the <a>secured data document</a>.

--- a/index.html
+++ b/index.html
@@ -1729,8 +1729,9 @@ If the <var>proof</var>.<var>type</var>,
 `MALFORMED_PROOF_ERROR` MUST be raised.
           </li>
           <li>
-If the cryptographic suite does not support unlinkability and the
-<var>proof</var>.<var>created</var> value is not set, a `MALFORMED_PROOF_ERROR`
+If the cryptographic suite requires the 
+<var>proof</var>.<var>created</var> value, and it 
+is not set, a `MALFORMED_PROOF_ERROR`
 MUST be raised.
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -1707,59 +1707,93 @@ digital proof.
       </section>
 
       <section>
-        <h3>Verify Proof Algorithm</h3>
-        <p class="issue">
-This algorithm is highly specific to digital signatures and needs to be
-generalized to other proof mechanisms such as Equihash.
-        </p>
+        <h3>Verify Proof</h3>
 
         <p>
 The following algorithm specifies how to check the authenticity and
-integrity of a <a>signed data document</a> by verifying its
-digital proof. This algorithm takes a
-<a>signed data document</a>, <var>signed document</var> and
-outputs a <code>true</code> or <code>false</code> value based on whether or
-not the digital proof on <var>signed document</var> was verified. Whenever
-this algorithm encodes strings, it MUST use UTF-8 encoding.
+integrity of a <a>secured data document</a> by verifying its
+digital proof. Required inputs are a
+<a>secured data document</a> (<var>securedDocument</var>) and
+<a>proof options</a> (<var>options</var>). A <dfn>verification result</dfn> is
+produced as output.
         </p>
-
-<div class="issue">Specify how the public key can be obtained, through
-some out-of-band process and passed in or it can be retrieved by
-derefencing its URL identifier, etc.</div>
 
         <ol class="algorithm">
           <li>
-Get the <a>public key</a> by dereferencing its URL identifier in the
-<code>proof</code> node of the default graph of <var>signed document</var>.
-Confirm that the <a>unsigned data document</a> that describes the <a>public
-key</a> specifies its controller and that its controllers's URL identifier can
-be dereferenced to reveal a bi-directional link back to the key. Ensure that the
-key's controller is a trusted entity before proceeding to the next step.
+Let <var>proof</var> be set to <var>securedDocument</var>.<var>proof</var>.
           </li>
           <li>
-Let <var>document</var> be a copy of <var>signed document</var>.
+If the <var>proof</var>.<var>type</var>,
+<var>proof</var>.<var>verificationMethod</var>, or
+<var>proof</var>.<var>proofPurpose</var> values are not set, a
+`MALFORMED_PROOF_ERROR` MUST be raised.
           </li>
           <li>
-Remove any <code>proof</code> nodes from the default graph in
-<var>document</var> and save it as <var>proof</var>.
+If the cryptographic suite does not support unlinkability and the
+<var>proof</var>.<var>created</var> value is not set, a `MALFORMED_PROOF_ERROR`
+MUST be raised.
           </li>
           <li>
-Generate a <var>transformed document</var> by canonicalizing
-<var>document</var> according to the <a>transformation algorithm</a>
-(e.g. the </var><em>URDNA2015</em> [[!RDF-DATASET-C14N]] algorithm).
+Let <var>unsecuredDocument</var> be a copy of <var>securedDocument</var> with
+the `proof` value removed.
           </li>
           <li>
-Create a value <var>tbv</var> that represents the data to be verified, and
-set it to the result of running the
-<a href="#dfn-hashing-algorithm">hashing algorithm</a>,
-passing the information in <var>proof</var>.
+Let <var>transformedDocument</var> be the result of
+<a href="#dfn-transformation">transforming</a> <var>unsecuredDocument</var>
+according to a <a>transformation algorithm</a> associated with the
+<var>cryptosuite</var> specified in <var>proof</var> and the <var>options</var>
+parameters provided as inputs to the algorithm.
+        </li>
+          <li>
+Let <var>hashData</var> be the result of
+<a href="#dfn-hashing">hashing</a> <var>transformedDocument</var>
+according to a <a>hashing algorithm</a> associated with the
+<var>cryptosuite</var> specified in <var>proof</var> and the <var>options</var>
+parameters provided as inputs to the algorithm.
           </li>
           <li>
-Pass the <a>proofValue</a>, <var>tbv</var>,
-and the <a>public key</a> to the <a>proof verification algorithm</a>.
-Return the resulting boolean value.
+Let <var>isProofValid</var> be the result of running the
+<a>proof verification algorithm</a> associated with the <var>cryptosuite</var>
+with the <var>hashData</var> and <var>options</var> parameters provided
+as inputs to the algorithm.
+          </li>
+          <li>
+If the <var>proof</var>.<var>proofPurpose</var> value does not match
+<var>options</var>.<var>proofPurpose</var>, a `MISMATCHED_PROOF_PURPOSE_ERROR`
+MUST be raised.
+          </li>
+          <li>
+If the <var>proof</var>.<var>created</var> is set and it deviates more than
+<var>options</var>.<var>acceptableCreatedTimeDeviationInSeconds</var> seconds, a
+`CREATED_TIME_DEVIATION_ERROR` MUST be raised.
+          </li>
+          <li>
+If <var>options</var>.<var>domain</var> is set and it does not match
+<var>proof</var>.<var>domain</var>, an `INVALID_DOMAIN_ERROR` MUST be raised.
+          </li>
+          <li>
+If <var>options</var>.<var>challenge</var> is set and it does not match
+<var>proof</var>.<var>challenge</var>, an `INVALID_CHALLENGE_ERROR` MUST be
+raised.
+          </li>
+          <li>
+Return <var>isProofValid</var> as the <a>verification result</a>.
           </li>
         </ol>
+
+        <p class="issue" title="Define how verification material is retrieved">
+Specify how <var>proof</var>.<var>verificationMethod</var> can be obtained,
+through some out-of-band process and passed in or it can be retrieved by
+derefencing its URL identifier, etc. It is expected that the <a>public key</a>
+is retrieved by dereferencing its URL identifier in the <code>proof</code> node
+of the default graph of <var>securedDocument</var>. The algorithm needs to
+confirm that the <a>verification method</a> that describes cryptographic
+material, such as the <a>public key</a>, specifies its <a>controller</a> and
+that its controllers's URL identifier can be dereferenced to reveal a
+bi-directional link back to the key. Ensure that the key's controller is a
+trusted entity before proceeding to the next step.
+        </p>
+
       </section>
 
     </section>


### PR DESCRIPTION
This PR updates the algorithm used to verify proofs to align with the language used to generate proofs (now merged into `main`).

At present, both the proof generation and proof verification algorithms presume only a single proof. The algorithms will need to be updated to support proof sets and proof chains in a future PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/64.html" title="Last updated on Oct 23, 2022, 8:50 PM UTC (520a357)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/64/47774a7...520a357.html" title="Last updated on Oct 23, 2022, 8:50 PM UTC (520a357)">Diff</a>