### PR TITLE
Add section on Proof Purpose Validation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,7 @@ challenge-response protocol.
             </p>
 
             <dl>
-              <dt><dfn>authentication</dfn></dt>
+              <dt>authentication</dt>
               <dd>
 The <code>authentication</code> property is OPTIONAL. If present, the associated
 value MUST be a <a data-cite="INFRA#ordered-set">set</a> of one or more
@@ -2210,6 +2210,28 @@ Implementers need to ensure that when a verification method is used, that
 it matches the verification relationship associated with it and that it lines
 up with the proof purpose.
         </p>
+      </section>
+
+      <section>
+        <h3>Proof Purpose Validation</h3>
+
+        <p>
+When an implementation is <a href="#verify-proof">verifying a proof</a>, it is
+imperative that it verify that the <a>proof purpose</a> match the intended use.
+        </p>
+
+        <p>
+This process is used to ensure that proofs are not misused by an application for
+an unintended purpose, as this is dangerous for the proof creator. An example of
+misuse would be if a proof that stated its purpose was for securing assertions
+in <a>verifiable credentials</a> was instead used for <a>authentication</a> to
+log into a website. In this case, the proof creator attached proofs to any
+number of <a>verifiable credentials</a> that they expected to be distributed to
+an unbounded number of other parties. Any one of these parties could log into a
+website as the proof creator if the website erroneously accepted such a proof as
+<a>authentication</a> instead of its intended purpose.
+        </p>
+
       </section>
 
       <section>

--- a/terms.html
+++ b/terms.html
@@ -52,11 +52,10 @@ include a <a>domain</a> in its digital proof to restrict its use
 to particular target, identified by the specified <a>domain</a>.
   </dd>
 
-  <dt><dfn data-lt="authenticated">authenticate</dfn></dt>
+  <dt><dfn data-lt="authenticated|authenticate">authentication</dfn></dt>
   <dd>
-Authentication is a process by which an entity can prove it has a specific
-attribute or controls a specific secret using one or more <a>verification
-methods</a>.
+A process by which an entity can prove to a verifier it that it has a specific
+attribute or controls a specific secret.
   </dd>
 
   <dt><dfn data-lt="cryptosuite">cryptographic suite</dfn></dt>

--- a/terms.html
+++ b/terms.html
@@ -54,7 +54,7 @@ to particular target, identified by the specified <a>domain</a>.
 
   <dt><dfn data-lt="authenticated|authenticate">authentication</dfn></dt>
   <dd>
-A process by which an entity can prove to a verifier it that it has a specific
+A process by which an entity can prove to a verifier that it has a specific
 attribute or controls a specific secret.
   </dd>
 


### PR DESCRIPTION
Added text [requested by @dlongley](https://github.com/w3c/vc-data-integrity/pull/75#discussion_r1083328345) to the Security Considerations section to clarify that `proofPurpose` needs to be validated when validating a proof.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/80.html" title="Last updated on Jan 28, 2023, 10:00 PM UTC (ac59766)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/80/e40bcc8...ac59766.html" title="Last updated on Jan 28, 2023, 10:00 PM UTC (ac59766)">Diff</a>