### PR TITLE
Add algorithm for retrieving a Verification Method.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1854,14 +1854,24 @@ If <var>vmIdentifier</var> is not a valid URL, an
 `INVALID_VERIFICATION_METHOD_URL` error MUST be raised.
           </li>
           <li>
+Let <var>controllerDocumentUrl</var> be the result of parsing
+<var>vmIdentifier</var> according to the rules of the URL scheme and extracting
+the primary resource identifier (without the fragment identifier).
+          </li>
+          <li>
 Let <var>vmFragment</var> be the result of parsing <var>vmIdentifier</var>
 according to the rules of the URL scheme and extracting the secondary
-resource identifier.
+resource identifier (the fragment identifier).
           </li>
           <li>
 Let <var>controllerDocument</var> be the result of dereferencing
-<var>vmIdentifier</var>, without <var>vmFragment</var>, according to the rules
+<var>controllerDocumentUrl</var>, according to the rules
 of the URL scheme and using the supplied <var>options</var>.
+          </li>
+          <li>
+If <var>controllerDocument</var>.<var>id</var> does not match the
+<var>controllerDocumentUrl</var>, a `INVALID_CONTROLLER_DOCUMENT_ID` error MUST
+be raised.
           </li>
           <li>
 If <var>controllerDocument</var> is not a valid <a>controller document</a>,

--- a/index.html
+++ b/index.html
@@ -1832,8 +1832,80 @@ trusted entity before proceeding to the next step.
       <section class="normative">
         <h3>Retrieve Verification Method</h3>
 
-      </section>
+        <p>
+The following algorithm specifies how to safely retrieve a verification method,
+such as a cryptographic public key, by using a <a>verification method</a>
+identifier contained in a <a>data integrity proof</a>. Required inputs are a
+<a>data integrity proof</a> (<var>proof</var>) and a set of
+<strong>dereferencing options</strong> (<var>options</var>). A
+<strong>verification method</strong> is produced as output.
+        </p>
 
+        <ol class="algorithm">
+          <li>
+Let <var>verificationMethod</var> be set to a `null` value.
+          </li>
+          <li>
+Let <var>vmIdentifier</var> be set to
+<var>proof</var>.<var>verificationMethod</var>.
+          </li>
+          <li>
+Let <var>vmPurpose</var> be set to <var>proof</var>.<var>proofPurpose</var>.
+          </li>
+          <li>
+If <var>vmIdentifier</var> is not a valid URL, an
+`INVALID_VERIFICATION_METHOD_URL` error MUST be raised.
+          </li>
+          <li>
+Let <var>controllerDocument</var> be the result of dereferencing
+<var>vmIdentifier</var>.
+          </li>
+          <li>
+If <var>controllerDocument</var> is not a valid <a>controller document</a>,
+an `INVALID_CONTROLLER_DOCUMENT` error MUST be raised.
+          </li>
+          <li>
+Let <var>verificationMethodArray</var> be an empty array. If the value of
+the <var>vmPurpose</var> property in the <var>controllerDocument</var> is a
+single value, add it to the  <var>verificationMethodArray</var>. If the value of
+the <var>vmPurpose</var> property in the <var>controllerDocument</var> is an
+array, add each item in the array to <var>verificationMethodArray</var>.
+          </li>
+          <li>
+For each <var>item</var> in <var>verificationMethodArray</var>:
+            <ol class="algorithm">
+              <li>
+If <var>item</var> is a string, replace <var>item</var> with the corresponding
+<var>expandedItem</var> in the
+<var>controllerDocument</var>.<var>verificationMethod</var> array. To determine
+if an <var>item</var> corresponds to an <var>expandedItem</var>, check for
+string equivalence between <var>item</var> and
+<var>expandedItem</var>.<var>id</var>. If a corresponding
+<var>expandedItem</var> does not exist, an `INVALID_VERIFICATION_METHOD`
+error MUST be raised.
+              </li>
+              <li>
+If the <var>item</var>.<var>id</var> value is equivalent to
+<var>vmIdentifier</var>, and <var>item</var>.<var>controller</var> is
+equivalent to <var>controllerDocument</var>.<var>id</var>, then set
+<var>verificationMethod</var> to <var>item</var>.
+              </li>
+            </ol>
+          </li>
+          <li>
+If <var>verificationMethod</var> is set to `null`, a
+`VERIFICATION_METHOD_NOT_FOUND` error MUST be raised.
+          </li>
+          <li>
+If <var>verificationMethod</var> is not a conforming <a>verification method</a>,
+a `INVALID_VERIFICATION_METHOD` error MUST be raised.
+          </li>
+          <li>
+Return <var>verificationMethod</var> as the
+<strong>verification method</strong>.
+          </li>
+        </ol>
+      </section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1843,9 +1843,6 @@ identifier contained in a <a>data integrity proof</a>. Required inputs are a
 
         <ol class="algorithm">
           <li>
-Let <var>verificationMethod</var> be set to a `null` value.
-          </li>
-          <li>
 Let <var>vmIdentifier</var> be set to
 <var>proof</var>.<var>verificationMethod</var>.
           </li>
@@ -1857,54 +1854,40 @@ If <var>vmIdentifier</var> is not a valid URL, an
 `INVALID_VERIFICATION_METHOD_URL` error MUST be raised.
           </li>
           <li>
+Let <var>vmFragment</var> be the result of parsing <var>vmIdentifier</var>
+according to the rules of the URL scheme and extracting the secondary
+resource identifier.
+          </li>
+          <li>
 Let <var>controllerDocument</var> be the result of dereferencing
-<var>vmIdentifier</var>.
+<var>vmIdentifier</var>, without <var>vmFragment</var>, according to the rules
+of the URL scheme and using the supplied <var>options</var>.
           </li>
           <li>
 If <var>controllerDocument</var> is not a valid <a>controller document</a>,
 an `INVALID_CONTROLLER_DOCUMENT` error MUST be raised.
           </li>
           <li>
-Let <var>verificationMethodArray</var> be an empty array. If the value of
-the <var>vmPurpose</var> property in the <var>controllerDocument</var> is a
-single value, add it to the  <var>verificationMethodArray</var>. If the value of
-the <var>vmPurpose</var> property in the <var>controllerDocument</var> is an
-array, add each item in the array to <var>verificationMethodArray</var>.
+Let <var>verificationMethod</var> be the result of dereferencing the
+<var>vmFragment</var> from the <var>controllerDocument</var> according to the
+rules of the associated URL scheme and using the supplied <var>options</var>.
           </li>
           <li>
-For each <var>item</var> in <var>verificationMethodArray</var>:
-            <ol class="algorithm">
-              <li>
-If <var>item</var> is a string, replace <var>item</var> with the corresponding
-<var>expandedItem</var> in the
-<var>controllerDocument</var>.<var>verificationMethod</var> array. To determine
-if an <var>item</var> corresponds to an <var>expandedItem</var>, check for
-string equivalence between <var>item</var> and
-<var>expandedItem</var>.<var>id</var>. If a corresponding
-<var>expandedItem</var> does not exist, an `INVALID_VERIFICATION_METHOD`
-error MUST be raised.
-              </li>
-              <li>
-If the <var>item</var>.<var>id</var> value is equivalent to
-<var>vmIdentifier</var>, and <var>item</var>.<var>controller</var> is
-equivalent to <var>controllerDocument</var>.<var>id</var>, then set
-<var>verificationMethod</var> to <var>item</var>.
-              </li>
-            </ol>
+If <var>verificationMethod</var> is not a valid <a>verification method</a>,
+an `INVALID_VERIFICATION_METHOD` error MUST be raised.
           </li>
           <li>
-If <var>verificationMethod</var> is set to `null`, a
-`VERIFICATION_METHOD_NOT_FOUND` error MUST be raised.
-          </li>
-          <li>
-If <var>verificationMethod</var> is not a conforming <a>verification method</a>,
-a `INVALID_VERIFICATION_METHOD` error MUST be raised.
+If <var>verificationMethod</var> does not exist in the <var>vmPurpose</var>
+property in the <var>controllerDocument</var>, either by reference (URL) or
+by value (object), an `INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD` error
+MUST be raised.
           </li>
           <li>
 Return <var>verificationMethod</var> as the
 <strong>verification method</strong>.
           </li>
         </ol>
+
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -1836,7 +1836,7 @@ trusted entity before proceeding to the next step.
 The following algorithm specifies how to safely retrieve a verification method,
 such as a cryptographic public key, by using a <a>verification method</a>
 identifier contained in a <a>data integrity proof</a>. Required inputs are a
-<a>data integrity proof</a> (<var>proof</var>) and a set of
+<strong><a>data integrity proof</a></strong> (<var>proof</var>) and a set of
 <strong>dereferencing options</strong> (<var>options</var>). A
 <strong>verification method</strong> is produced as output.
         </p>
@@ -1870,7 +1870,7 @@ of the URL scheme and using the supplied <var>options</var>.
           </li>
           <li>
 If <var>controllerDocument</var>.<var>id</var> does not match the
-<var>controllerDocumentUrl</var>, a `INVALID_CONTROLLER_DOCUMENT_ID` error MUST
+<var>controllerDocumentUrl</var>, an `INVALID_CONTROLLER_DOCUMENT_ID` error MUST
 be raised.
           </li>
           <li>
@@ -1880,7 +1880,7 @@ an `INVALID_CONTROLLER_DOCUMENT` error MUST be raised.
           <li>
 Let <var>verificationMethod</var> be the result of dereferencing the
 <var>vmFragment</var> from the <var>controllerDocument</var> according to the
-rules of the associated URL scheme and using the supplied <var>options</var>.
+rules of the media type of the <var>controllerDocument</var>.
           </li>
           <li>
 If <var>verificationMethod</var> is not a valid <a>verification method</a>,
@@ -1888,7 +1888,7 @@ an `INVALID_VERIFICATION_METHOD` error MUST be raised.
           </li>
           <li>
 If <var>verificationMethod</var> is not associated with the array of
-<var>vmPurpose</var>s in the <var>controllerDocument</var>, either by reference
+<var>vmPurposes</var> in the <var>controllerDocument</var>, either by reference
 (URL) or by value (object), an `INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD`
 error MUST be raised.
           </li>

--- a/index.html
+++ b/index.html
@@ -1887,10 +1887,10 @@ If <var>verificationMethod</var> is not a valid <a>verification method</a>,
 an `INVALID_VERIFICATION_METHOD` error MUST be raised.
           </li>
           <li>
-If <var>verificationMethod</var> does not exist in the <var>vmPurpose</var>
-property in the <var>controllerDocument</var>, either by reference (URL) or
-by value (object), an `INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD` error
-MUST be raised.
+If <var>verificationMethod</var> is not associated with the array of
+<var>vmPurpose</var>s in the <var>controllerDocument</var>, either by reference
+(URL) or by value (object), an `INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD`
+error MUST be raised.
           </li>
           <li>
 Return <var>verificationMethod</var> as the

--- a/index.html
+++ b/index.html
@@ -1888,6 +1888,25 @@ Return <var>verificationMethod</var> as the
           </li>
         </ol>
 
+        <p>
+The following example provides a minimum conformant
+<a>controller document</a> containing a minimum conformant
+<a>verification method</a> as required by the algorithm in this section:
+        </p>
+
+        <pre class="example" title="Minimum conformant controller document">
+{
+  "id": "https://controller.example/123",
+  "verificationMethod": [{
+    "id": "https://controller.example/123#key-456",
+    "type": "ExampleVerificationMethodType",
+    "controller": "https://controller.example/123",
+    <span class="comment">// public cryptographic material goes here</span>
+  }],
+  "authentication": ["#key-456"]
+}
+        </pre>
+
       </section>
     </section>
 


### PR DESCRIPTION
This PR adds the algorithm for retrieving a verification method, such as a cryptographic public key, from a controller document, such as a DID Document, given a verification method URL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/86.html" title="Last updated on Mar 17, 2023, 5:56 PM UTC (a46507a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/86/7cdb5e2...a46507a.html" title="Last updated on Mar 17, 2023, 5:56 PM UTC (a46507a)">Diff</a>