### PR TITLE
Use Specref VC-DATA-MODEL-2.0 ref.

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,17 +138,6 @@
               ],
               status: "CG-DRAFT",
               publisher: "Credentials Community Group"
-            },
-            "VC-DATA-MODEL-2": {
-              title: "Verifiable Credentials Data Model v2.0",
-              href: "https://www.w3.org/TR/vc-data-model-2.0/",
-              authors: [
-                "Manu Sporny", "Dave Longley", "Grant Noble", "Dan Burnett",
-                "Ted Thibodeau", "Brent Zundel", "David Chadwick",
-                "Kyle Den Hartog"
-              ],
-              status: "Working Draft",
-              publisher: "W3C Verifiable Credentials Working Group"
             }
           },
           postProcess: [restrictRefs]
@@ -188,7 +177,7 @@ used to:
         <li>
 Make statements that can be shared without loss of trust, because their
 authorship can be verified by a third party, for example as part of Verifiable
-Credentials [[VC-DATA-MODEL-2]] or social media posts.
+Credentials [[VC-DATA-MODEL-2.0]] or social media posts.
         </li>
         <li>
 Authenticate as an entity identified by a particular identifier, for example, as
@@ -1264,7 +1253,7 @@ the value of `controller` needs to <a>authenticate</a> with its
             <p>
 The `assertionMethod` <a>verification relationship</a> is used to
 specify how the <a>controller</a> is expected to express claims, such as for
-the purposes of issuing a Verifiable Credential [[?VC-DATA-MODEL-2]].
+the purposes of issuing a Verifiable Credential [[?VC-DATA-MODEL-2.0]].
             </p>
 
             <dl>

--- a/terms.html
+++ b/terms.html
@@ -130,7 +130,7 @@ is valid.
   <dd>
 A standard data model and representation format for cryptographically-verifiable
 digital credentials as defined by the W3C Verifiable Credentials specification
-[[?VC-DATA-MODEL-2]].
+[[?VC-DATA-MODEL-2.0]].
   </dd>
 
   <dt><dfn data-lt="">verification method</dfn></dt>


### PR DESCRIPTION
Specref has VC-DATA-MODEL-2.0 but not VC-DATA-MODEL-2. The use of VC-DATA-MODEL-2 in terms.html is an issue for other vc-di-* specs that include it directly. They can't find the Specref reference. This patch removes the localBiblio entry and adjusts references to the known Specref name.

An alternate approach would be to add VC-DATA-MODEL-2 to Specref.  I'm not sure what best practice is in this case.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/vc-data-integrity/pull/91.html" title="Last updated on Apr 12, 2023, 9:35 PM UTC (9b776b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/91/47f3a4c...davidlehn:9b776b2.html" title="Last updated on Apr 12, 2023, 9:35 PM UTC (9b776b2)">Diff</a>