### PR TITLE
Remove multibase requirement from proofValue type

### DIFF
--- a/contexts/data-integrity/v1
+++ b/contexts/data-integrity/v1
@@ -61,8 +61,7 @@
         },
         "cryptosuite": "https://w3id.org/security#cryptosuite",
         "proofValue": {
-          "@id": "https://w3id.org/security#proofValue",
-          "@type": "https://w3id.org/security#multibase"
+          "@id": "https://w3id.org/security#proofValue"
         },
         "verificationMethod": {
           "@id": "https://w3id.org/security#verificationMethod",


### PR DESCRIPTION
Including this requirement forces implementers to bundle multibase which is not yet a standard.

it also forces them to bundle multformats which is not a standard.

Bundling base58btc and base64url and others... 

I suggest leaving `proofType` a regular string, that is understood in the context of its associated `cryptosuite`.

In the future, when multibase becomes a standard, it seems wise to follow the "sorta convention" established by "did core", and call the multibase version of proof;

proofMultibase - https://www.w3.org/TR/did-core/#dfn-publickeymultibase