### PR TITLE
Deprecate `Ed25519Signature2020`

### DIFF
--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -40,7 +40,7 @@ class:
         url: https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof
 
   - id: Ed25519Signature2020
-    label: ED2559 Signature Suite, 2020 version
+    label: Ed25519 Signature Suite, 2020 version
     upper_value: sec:Proof
     deprecated: true
     comment: T.B.D.

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -42,6 +42,7 @@ class:
   - id: Ed25519Signature2020
     label: ED2559 Signature Suite, 2020 version
     upper_value: sec:Proof
+    deprecated: true
     comment: T.B.D.
 
 # These are the class definitions in the CCG documents that are not defined in the VCWG document; they are all deprecated


### PR DESCRIPTION
The current spec says, in https://www.w3.org/TR/vc-di-eddsa/#the-ed25519signature2020-suite:

> Ed25519Signature2020 is an earlier version of a cryptographic suite for the usage of the EdDSA algorithm and Curve25519. While it has been used in production systems, new implementations should use edssa-2022 instead. It has been kept in this specification to provide a stable reference.

On the other hand, the section on deprecation in the vocabulary introduces deprecation saying, in https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html#deprecated_term_definitions:

> All terms in this section are deprecated, and are only kept in this vocabulary for backward compatibility.
>
> New applications should not use them.

In my reading this means `Ed25519Signature2020` should be considered as deprecated. Otherwise some of these texts must change...

