### PR TITLE
Change proof id from URL to URI to better match examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@ The following attributes are defined for use in a <a>data integrity proof</a>:
         <dl style="margin-left: 1em;">
           <dt>id</dt>
           <dd>
-An optional identifier for the proof, which MUST be a URL [[URL]], such as
+An optional identifier for the proof, which MUST be a URI [[URI]], such as
 a UUID as a URN (`urn:uuid:6a1676b8-b51f-11ed-937b-d76685a20ff5`).
 The usage of this property is further explained in Section
 <a href="#proof-chains"></a>.


### PR DESCRIPTION
This is a draft as it might be incorrect. Currently the specification has an error in an example:

> An optional identifier for the proof, which MUST be a [URL](https://www.w3.org/TR/vc-data-integrity/#bib-url) [URL], such as a UUID as a URN (urn:uuid:6a1676b8-b51f-11ed-937b-d76685a20ff5). The usage of this property is further explained in Section [2.1.2 Proof Chains](https://www.w3.org/TR/vc-data-integrity/#proof-chains)

A URN is not a URL as defined here: https://datatracker.ietf.org/doc/html/rfc3986

So I changed the optional proof id to be a URI. I'm not sure if URI is auto-populated as normative reference by whatever library auto-populates the references.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aljones15/vc-data-integrity/pull/100.html" title="Last updated on Jun 16, 2023, 9:27 PM UTC (9106c8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/100/98bf34d...aljones15:9106c8f.html" title="Last updated on Jun 16, 2023, 9:27 PM UTC (9106c8f)">Diff</a>