### PR TITLE
Fix the sec prefix in the vocabulary.

### DIFF
--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -1,6 +1,6 @@
 vocab:
   id: sec
-  value: https://w3id.org/security/v1
+  value: https://w3id.org/security#
 
 prefix:
   - id: cred


### PR DESCRIPTION
Partial fix for issue #72, which corrects the `sec` URL in the base vocabulary file.