### PR TITLE
Add Greg and Sebastian as Editors to VC Data Integrity

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, these people will be requested for
 # review when someone opens a pull request.
-*       @msporny
+*       @msporny @Wind4Greg @seabass-labrax

--- a/index.html
+++ b/index.html
@@ -50,6 +50,12 @@
             name: "Dave Longley", url: "https://digitalbazaar.com/",
             company: "Digital Bazaar", companyURL: "http://digitalbazaar.com/",
             note: "2014-2022", w3cid: 48025
+          }, {
+            name: "Greg Bernstein", url: "https://www.grotto-networking.com/",
+            company: "Invited Expert", w3cid: 0
+          }, {
+            name: "Sebastian Crane", url: "https://github.com/seabass-labrax",
+            company: "Invited Expert", w3cid: 0
           }],
 
           // authors, add as many as you like.

--- a/index.html
+++ b/index.html
@@ -52,10 +52,10 @@
             note: "2014-2022", w3cid: 48025
           }, {
             name: "Greg Bernstein", url: "https://www.grotto-networking.com/",
-            company: "Invited Expert", w3cid: 0
+            company: "Invited Expert", w3cid: 140479
           }, {
             name: "Sebastian Crane", url: "https://github.com/seabass-labrax",
-            company: "Invited Expert", w3cid: 0
+            company: "Invited Expert", w3cid: 140132
           }],
 
           // authors, add as many as you like.


### PR DESCRIPTION
This PR adds Greg and Sebastian as Editors to the Data Integrity specification. The PR shouldn't be processed until after Sebastian's IE application has been processed. /cc @Wind4Greg @seabass-labrax


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/113.html" title="Last updated on Jul 13, 2023, 9:52 PM UTC (60342e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/113/211352d...60342e4.html" title="Last updated on Jul 13, 2023, 9:52 PM UTC (60342e4)">Diff</a>