### PR TITLE
Add hashes for context and vocab files.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1522,56 +1522,75 @@ SANah1u7rLk6Uw6GeQGH1w==
         </table>
 
         <p>
-Implementations that perform RDF vocabulary processing MUST 1) be implemented
-such that the vocabulary URLs used in the JSON-LD contexts listed above
-resolve to the files listed below, and 2) match the listed cryptographic
-hashes (if specified). The vocabulary content at the URLs listed below is
-normative.
+The security vocabulary terms that the JSON-LD contexts listed above resolve
+to are in the <a href="https://w3id.org/security">https://w3id.org/security#</a>
+namespace. That is, all security terms in this vocabulary are of the form
+`https://w3id.org/security#TERM`, where `TERM` is the name of a term.
+        </p>
+
+        <p>
+Implementations that perform RDF processing MUST treat the following
+JSON-LD vocabulary URL as already resolved, where the resolved document matches
+the corresponding hash values below.
+        </p>
+
+        <p>
+When dereferencing the
+<a href="https://w3id.org/security">https://w3id.org/security#</a> URL,
+the data returned depends on HTTP content negotiation. These are as follows:
         </p>
 
         <table class="simple">
           <thead>
             <tr>
-              <th>URL and Media Type</th>
-              <th>Content</th>
+              <th>Media Type</th>
+              <th>Description and Cryptographic Hashes</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td>
-https://w3id.org/security#<br>
-text/html
+application/ld+json
               </td>
               <td>
-https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html
+The vocabulary in JSON-LD format [[?JSON-LD]].<br><br>
+
+sha256: LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=<br><br>
+
+sha3-512: f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==
               </td>
             </tr>
             <tr>
               <td>
-https://w3id.org/security#<br>
-application/ld+json
+text/turtle
               </td>
               <td>
-https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
-sha256: snzV1JA8H7YB4AAQIH6qLzv48ZOhJ3oCl/ewvf0EBMg=<br><br>
-sha3-512: 7QUmDvF24f0/J0I7ZYpZrtlGIHcsjGXGfjBseg5e3j<wbr>xDZlTqd4P7tklHdKn3fwmT
-yKO1kwi0jv9/DLNjWbMrHA==
+The vocabulary in Turtle format [[?TURTLE]].<br><br>
+sha256: McnhLyt7+/A/0iLb3CUXD0itNw+7bwwjtzOww/zwoyI=<br><br>
+sha3-512: jZtZsqgPPPo+jphAcN8/St4VdRLLAmN3nEQhzs0twE<wbr>MTmCY45euQ01Z4Zo7VlJMYNTf0KC6BMpogpSTAi/1J7Q==
+              </td>
+              <td>
+              </td>
+            </tr>
+            <tr>
+              <td>
+text/html
+              </td>
+              <td>
+The vocabulary in HTML+RDFa Format [[?HTML-RDFA]].<br><br>
+sha256: eUHP1xiSC157iTPDydZmxg/hvmX3g/nnCn+FO25d4dc=<br><br>
+sha3-512: z53j8ryjVeX16Z/dby//ujhw37degwi09+LAZCTUB8<wbr>WJZjjzW1AydhdEWmgHM0P5KUcPMmSe7edMlGr7G9rmcA==
+              </td>
+              <td>
               </td>
             </tr>
           </tbody>
         </table>
 
-        <p class="issue" title="w3c.github.io links expected to change">
-The URLs listed above that start with
-`https://w3c.github.io/vc-data-integrity/vocab/security/` are expected to change
-to `https://www.w3.org/ns/security/` or an equally normative and archived
-location under W3C control.
-        </p>
-
         <p>
 It is possible to confirm the digests listed above by running the following
 command from a modern Unix command interface line:
-`curl -s &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`.
+`curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -1568,6 +1568,12 @@ to `https://www.w3.org/ns/security/` or an equally normative and archived
 location under W3C control.
         </p>
 
+        <p>
+It is possible to confirm the digests listed above by running the following
+command from a modern Unix command interface line:
+`curl -s &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`.
+        </p>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1475,6 +1475,55 @@ this specification.
 
       </section>
 
+      <section>
+        <h2>Contexts and Vocabularies</h2>
+
+        <p class="issue" title="(AT RISK) Hash values might change during Candidate Recommendation">
+This section lists cryptographic hash values that might change during the
+Candidate Recommendation phase based on implementer feedback that requires
+the referenced files to be modified.
+        </p>
+        <p>
+Implementations that perform JSON-LD processing MUST treat the following
+JSON-LD context URLs as already resolved, where the resolved document matches
+the corresponding hash values below:
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>URL and Media Type</th>
+              <th>Content</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style="white-space: nowrap;">
+https://www.w3.org/ns/data-integrity/v1<br>
+application/ld+json
+              </td>
+              <td>
+sha256: v/POI0jhSjPansxhJAP1fwepCBZ2HK77fRZfCCyBDs0=<br><br>
+sha3-512: Sg1PLFxKyEYQns9Zr0BoYXtFeDNfrHUDNMkyq4QEWv<wbr>wGIaX1v5xovnCG+dfceZEzr7BhBjm396noZF1HEeCM8g==
+              </td>
+            </tr>
+            <tr>
+              <td style="white-space: nowrap;">
+https://www.w3.org/ns/multikey/v1<br>
+application/ld+json
+              </td>
+              <td>
+sha256: SA+P0RxXl8ZH6xdPcmX71crzeGkCYMPfYjdVT46SF0o=<br><br>
+sha3-512: BgQBN00t6vj1T4uYt5SwdPOhe2BVNY11UEvkVo/rbBv<wbr>fBd+Z09isxhGhf2HkVqMT
+SANah1u7rLk6Uw6GeQGH1w==
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+
+      </section>
+
     </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -616,7 +616,7 @@ validity of cryptographic proofs, implementers are advised to respect the
 and local calendar preferences of the individual [[?LTLI]]. Conversion of
 timestamps to local time values are expected to consider the time zone
 expectations of the individual. See
-<a data-cite="VC-DATA-MODEL-2.0#representing-time"></a> for more details about
+<a data-cite="?VC-DATA-MODEL-2.0#representing-time"></a> for more details about
 representing time values to individuals.
         </p>
 
@@ -1576,8 +1576,8 @@ command from a modern Unix command interface line:
 
         <p>
 For further information regarding processing of JSON-LD Contexts and
-Vocabularies, see <a data-cite="VC-DATA-MODEL-2.0#base-context">Verifiable
-Credentials v2.0: Base Context</a> and <a data-cite="VC-DATA-MODEL-2.0#vocabularies">
+Vocabularies, see <a data-cite="?VC-DATA-MODEL-2.0#base-context">Verifiable
+Credentials v2.0: Base Context</a> and <a data-cite="?VC-DATA-MODEL-2.0#vocabularies">
 Verifiable Credentials v2.0: Vocabularies</a>.
         </p>
 
@@ -2558,7 +2558,7 @@ validity period of cryptographic proofs. This information might be indirectly
 exposed to an individual if a proof is processed and is detected to be outside
 an allowable time range. When exposing these dates and times to an individual,
 implementers are urged to take into account
-<a data-cite="VC-DATA-MODEL-2.0#representing-time">cultural norms when
+<a data-cite="?VC-DATA-MODEL-2.0#representing-time">cultural norms when
 representing dates and times</a>, as well as ensuring that the value is
 <a href="#representing-time">displayed according to provided locale settings</a>
 in display software. In addition to these considerations, presenting time

--- a/index.html
+++ b/index.html
@@ -1521,6 +1521,52 @@ SANah1u7rLk6Uw6GeQGH1w==
           </tbody>
         </table>
 
+        <p>
+Implementations that perform RDF vocabulary processing MUST 1) be implemented
+such that the vocabulary URLs used in the JSON-LD contexts listed above
+resolve to the files listed below, and 2) match the listed cryptographic
+hashes (if specified). The vocabulary content at the URLs listed below are
+normative.
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>URL and Media Type</th>
+              <th>Content</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+https://w3id.org/security#<br>
+text/html
+              </td>
+              <td>
+https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html
+              </td>
+            </tr>
+            <tr>
+              <td>
+https://w3id.org/security#<br>
+application/ld+json
+              </td>
+              <td>
+https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
+sha256: snzV1JA8H7YB4AAQIH6qLzv48ZOhJ3oCl/ewvf0EBMg=<br><br>
+sha3-512: 7QUmDvF24f0/J0I7ZYpZrtlGIHcsjGXGfjBseg5e3j<wbr>xDZlTqd4P7tklHdKn3fwmT
+yKO1kwi0jv9/DLNjWbMrHA==
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="issue" title="w3c.github.io links expected to change">
+The URLs listed above that start with
+`https://w3c.github.io/vc-data-integrity/vocab/security/` are expected to change
+to `https://www.w3.org/ns/security/` or an equally normative and archived
+location under W3C control.
+        </p>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1574,6 +1574,13 @@ command from a modern Unix command interface line:
 `curl -s &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`.
         </p>
 
+        <p>
+For further information regarding processing of JSON-LD Contexts and
+Vocabularies, see <a data-cite="VC-DATA-MODEL-2.0#base-context">Verifiable
+Credentials v2.0: Base Context</a> and <a data-cite="VC-DATA-MODEL-2.0#vocabularies">
+Verifiable Credentials v2.0: Vocabularies</a>.
+        </p>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1525,7 +1525,7 @@ SANah1u7rLk6Uw6GeQGH1w==
 Implementations that perform RDF vocabulary processing MUST 1) be implemented
 such that the vocabulary URLs used in the JSON-LD contexts listed above
 resolve to the files listed below, and 2) match the listed cryptographic
-hashes (if specified). The vocabulary content at the URLs listed below are
+hashes (if specified). The vocabulary content at the URLs listed below is
 normative.
         </p>
 


### PR DESCRIPTION
This PR addresses issue #115 by normatively referring to the appropriate JSON-LD Context files and vocabulary documents. This is similar to the language in the VC v2.0 specification:

https://w3c.github.io/vc-data-model/#base-context

... but follows @jyasskin's suggestion on treating values as already dereferenced. Where it makes sense, cryptographic hashes are provided and implementers are instructed to NOT load the documents from the Web, but rather treat them as already dereferenced with the contents of the files identified by cryptographic hash.

@iherman, pay particular attention to the cryptographic hash value for the machine-readable vocabulary and the normative statement related to it. If you are ok with that approach here, I can do something similar for the VC v2.0 specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/116.html" title="Last updated on Jul 28, 2023, 8:51 PM UTC (b24a862)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/116/7f07983...b24a862.html" title="Last updated on Jul 28, 2023, 8:51 PM UTC (b24a862)">Diff</a>