### PR TITLE
Make "created" proof attribute optional.

### DIFF
--- a/index.html
+++ b/index.html
@@ -486,8 +486,8 @@ by a verifier during the verification process.
 
           <dt>created</dt>
           <dd>
-The date and time the proof was created MUST be specified as an
-[[XMLSCHEMA11-2]] combined date and time string.
+The date and time the proof was created is OPTIONAL and, if included, MUST be 
+specified as an [[XMLSCHEMA11-2]] combined date and time string.
           </dd>
 
           <dt>domain</dt>
@@ -1619,9 +1619,9 @@ which  can be used to verify the authenticity and integrity of an
 <a>cryptographic suite</a> (<var>type</var>) and any other properties needed by
 the <a>cryptographic suite</a> type; an identifier for the
 <a>verification method</a> (<var>verificationMethod</var>) that can be used to
-verify the authenticity of the proof; and an [[!XMLSCHEMA11-2]] combined date
+verify the authenticity of the proof;  An [[!XMLSCHEMA11-2]] combined date
 and time string (<var>created</var>) containing the current date and time,
-accurate to at least one second, in Universal Time Code format. A
+accurate to at least one second, in Universal Time Code format, a
 <a href="#dfn-domain">security domain</a> (<var>domain</var>) and
 receiver-supplied challenge (<var>challenge</var>) might also be specified in
 the <var>options</var>. A <dfn>secured data document</dfn> is produced as

--- a/index.html
+++ b/index.html
@@ -1622,7 +1622,7 @@ the <a>cryptographic suite</a> type; an identifier for the
 verify the authenticity of the proof; an [[!XMLSCHEMA11-2]] combined date
 and time string (<var>created</var>) containing the current date and time,
 accurate to at least one second, in Universal Time Code format, a
-<a href="#dfn-domain">security domain</a> (<var>domain</var>) and
+<a href="#dfn-domain">security domain</a> (<var>domain</var>), and a
 receiver-supplied challenge (<var>challenge</var>) might also be specified in
 the <var>options</var>. A <dfn>secured data document</dfn> is produced as
 output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.

--- a/index.html
+++ b/index.html
@@ -1619,7 +1619,7 @@ which  can be used to verify the authenticity and integrity of an
 <a>cryptographic suite</a> (<var>type</var>) and any other properties needed by
 the <a>cryptographic suite</a> type; an identifier for the
 <a>verification method</a> (<var>verificationMethod</var>) that can be used to
-verify the authenticity of the proof;  An [[!XMLSCHEMA11-2]] combined date
+verify the authenticity of the proof; an [[!XMLSCHEMA11-2]] combined date
 and time string (<var>created</var>) containing the current date and time,
 accurate to at least one second, in Universal Time Code format, a
 <a href="#dfn-domain">security domain</a> (<var>domain</var>) and


### PR DESCRIPTION
To resolve issue https://github.com/w3c/vc-data-integrity/issues/23 I made the `created` proof option attribute OPTIONAL. This required small updates in the [Proofs](https://w3c.github.io/vc-data-integrity/#proofs) section and in the [Add Proof](https://w3c.github.io/vc-data-integrity/#add-proof) algorithm section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/118.html" title="Last updated on Jul 19, 2023, 4:03 PM UTC (34bcce7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/118/7f07983...Wind4Greg:34bcce7.html" title="Last updated on Jul 19, 2023, 4:03 PM UTC (34bcce7)">Diff</a>