### PR TITLE
Add section on relationship to Verifiable Credentials

### DIFF
--- a/index.html
+++ b/index.html
@@ -1492,14 +1492,24 @@ verifiable presentations</a>. Implementers
 that are addressing those use cases are cautioned that additional checks might
 be appropriate when processing those types of documents. For example, there are
 some use cases where it is important to ensure that the
-<a href="#proofs">`proof.verificationMethod`</a> value is associated with the
-<a data-cite="VC-DATA-MODEL-2.0#issuer">`issuer`</a> URL value in a
+<a>verification method</a> used in a proof is associated with the
+<a data-cite="VC-DATA-MODEL-2.0#issuer">`issuer`</a> in a
 <a data-cite="VC-DATA-MODEL-2.0#dfn-verifiable-credential">
 verifiable credential</a>, or the
-<a data-cite="VC-DATA-MODEL-2.0#issuer">`holder`</a> URL value in a
-<a data-cite="VC-DATA-MODEL-2.0#dfn-verifiable-credential">
+<a data-cite="VC-DATA-MODEL-2.0#dfn-holders">`holder`</a> in a
+<a data-cite="VC-DATA-MODEL-2.0#dfn-verifiable-presentation">
 verifiable presentation</a>, during the process of
-<a data-cite="VC-DATA-MODEL-2.0#issuer-0">validation</a>.
+<a data-cite="VC-DATA-MODEL-2.0#issuer-0">validation</a>. One
+way to check for such an association is to ensure that the value of the
+<code>controller</code> property of a proof's <a>verification method</a>
+matches the URL value used to identify the
+<a data-cite="VC-DATA-MODEL-2.0#issuer">`issuer`</a> or
+<a data-cite="VC-DATA-MODEL-2.0#dfn-holder">`holder`</a>, respectively.
+This particular association indicates that the
+<a data-cite="VC-DATA-MODEL-2.0#issuer">`issuer`</a> or
+<a data-cite="VC-DATA-MODEL-2.0#dfn-holder">`holder`</a>, respectively,
+is the controller of the <a>verification method</a> used to verify
+the proof.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -492,7 +492,7 @@ by a verifier during the verification process.
 
           <dt>created</dt>
           <dd>
-The date and time the proof was created is OPTIONAL and, if included, MUST be 
+The date and time the proof was created is OPTIONAL and, if included, MUST be
 specified as an [[XMLSCHEMA11-2]] combined date and time string.
           </dd>
 
@@ -1482,6 +1482,28 @@ this specification.
       </section>
 
       <section>
+        <h2>Relationship to Verifiable Credentials</h2>
+        <p>
+Cryptographic suites that implement this specification can be used to secure
+<a data-cite="VC-DATA-MODEL-2.0#dfn-verifiable-credential">
+verifiable credentials</a> and
+<a data-cite="VC-DATA-MODEL-2.0#dfn-verifiable-presentation">
+verifiable presentations</a>. Implementers
+that are addressing those use cases are cautioned that additional checks might
+be appropriate when processing those types of documents. For example, there are
+some use cases where it is important to ensure that the
+<a href="#proofs">`proof.verificationMethod`</a> value is associated with the
+<a data-cite="VC-DATA-MODEL-2.0#issuer">`issuer`</a> URL value in a
+<a data-cite="VC-DATA-MODEL-2.0#dfn-verifiable-credential">
+verifiable credential</a>, or the
+<a data-cite="VC-DATA-MODEL-2.0#issuer">`holder`</a> URL value in a
+<a data-cite="VC-DATA-MODEL-2.0#dfn-verifiable-credential">
+verifiable presentation</a>, during the process of
+<a data-cite="VC-DATA-MODEL-2.0#issuer-0">validation</a>.
+        </p>
+      </section>
+
+      <section>
         <h2>Contexts and Vocabularies</h2>
 
         <p class="issue" title="(AT RISK) Hash values might change during Candidate Recommendation">
@@ -1729,7 +1751,7 @@ in a sub-optimal developer experience. A streamlined version of this design
 pattern emerged in 2020, such that a developer would only need to include a
 single JSON-LD Context to support all modern cryptographic suites. This
 encouraged more modern cryptosuites &mdash; such as the EdDSA Cryptosuites
-[[?DI-EDDSA]] and the ECDSA Cryptosuites [[?DI-ECDSA]] &mdash; to be built 
+[[?DI-EDDSA]] and the ECDSA Cryptosuites [[?DI-ECDSA]] &mdash; to be built
 based on the streamlined pattern described in this section.
         <br><br>
 To improve the developer experience, authors creating new Data Integrity

--- a/terms.html
+++ b/terms.html
@@ -22,7 +22,7 @@ Cryptographic material that can be used to generate digital proofs.
   <dd>
 A specified set of cryptographic primitives bundled together into a
 <a>cryptographic suite</a> for the purposes of safety and convenience, by
-cryptographers for developers (see the section on 
+cryptographers for developers (see the section on
 <a href="https://www.w3.org/TR/vc-data-integrity/#cryptographic-suites">cryptographic suites</a>).
   </dd>
   <dt><dfn>proof options</dfn></dt>
@@ -128,9 +128,17 @@ is valid.
   <dt><dfn data-lt="verifiable credentials">verifiable credential</dfn></dt>
 
   <dd>
-A standard data model and representation format for cryptographically-verifiable
-digital credentials as defined by the W3C Verifiable Credentials specification
-[[?VC-DATA-MODEL-2.0]].
+A standard data model and representation format for expressing
+cryptographically-verifiable digital credentials as defined by the W3C
+Verifiable Credentials specification [[?VC-DATA-MODEL-2.0]].
+  </dd>
+
+  <dt><dfn data-lt="verifiable presentations">verifiable presentation</dfn></dt>
+
+  <dd>
+A standard data model and representation format for presenting
+cryptographically-verifiable digital credentials as defined by the W3C
+Verifiable Credentials specification [[?VC-DATA-MODEL-2.0]].
   </dd>
 
   <dt><dfn data-lt="">verification method</dfn></dt>


### PR DESCRIPTION
This PR attempts to address issue #77 by adding a section to the specification called "Relationship to Verifiable Credentials" and noting that other checks might be performed based on information in the proof, such as checking against a VC's `issuer` property. The section cross-links to the VCDM v2.0 specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/119.html" title="Last updated on Jul 28, 2023, 9:00 PM UTC (4abcdd3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/119/4632915...4abcdd3.html" title="Last updated on Jul 28, 2023, 9:00 PM UTC (4abcdd3)">Diff</a>