### PR TITLE
Added algorithms related to proof sets and chains.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1821,7 +1821,7 @@ Return <var>isProofVerified</var> as the <a>verification result</a>.
       <section>
         <h3>Verify Proof Sets and Chains</h3>
         <p>
-In the case of a proof set or proof chain a <a>secured data document</a> has a 
+In a proof set or proof chain, a <a>secured data document</a> has a 
 <code>proof</code> attribute which contains a list of proofs 
 (<var>proof_list</var>).
 The following algorithm specifies how to check the authenticity and
@@ -1835,19 +1835,19 @@ verification results is produced as output.
 Set <var>proof_list</var> to </var><var>securedDocument</var>.<var>proof</var>. 
           </li>
           <li>
-For each <var>proof</var> in <var>proof_list</var> run steps 2-11 of the algorithm in
-section <a href="verify-proof"></a> and if no exceptions are raised, associate
+For each <var>proof</var> in <var>proof_list</var>, run steps 2&ndash;11 of the algorithm in
+section <a href="verify-proof"></a>, and if no exceptions are raised, associate
 the <var>isProofVerified</var> value with this <var>proof</var>.
           </li>
           <li>
 For each <var>proof</var> in <var>proof_list</var> that contains a 
-<code>previousProof</code> attribute modify the associated 
-<var>isProofVerified</var> by iteratively checking that the proof identified by
-the <code>id</code> value in <var>previousProof</var> is valid along with any 
+<code>previousProof</code> attribute, modify the associated 
+<var>isProofVerified</var> by iteratively checking whether the proof identified by
+the <code>id</code> value in <var>previousProof</var> is valid, along with any 
 <code>previousProofs</code> up the chain.
           </li>
           <li>
-Return the <var>proof_list</var> along with each proofs associated 
+Return the <var>proof_list</var> along with each proof's associated 
 <var>isProofVerified</var> information.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -1692,71 +1692,52 @@ via the digital proof.
 
       </section>
       <section>
-        <h3>Add Proof Set</h3>
+        <h3>Add Proof Set/Chain</h3>
         <p>
-          The following algorithm specifies how to add a proof set to a 
-          document. Required inputs are an
-          <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
-          list (unordered) of
-          <a>proof options</a> (<var>options_list</var>). Each <a>proof options</a>
-          (<var>options</var>) in the list must satisfy the criteria in 
+          The following algorithm specifies how to incrementally add a proof to 
+          a proof set or proof chain starting with a secured document containing
+          either a proof or proof set/chain.
+          Required inputs are a <a>secured data document</a> 
+          (<var>securedDocument</var>) and <a>proof options</a> 
+          (<var>options</var>). The <a>proof options</a>
+          (<var>options</var>) must satisfy the criteria in 
           section <a href="#add-proof"></a>.
-          A <dfn>secured data document</dfn> is produced as
-          output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
+          A new <dfn>secured data document</dfn> is produced as
+          output. Whenever this algorithm encodes strings, it MUST use UTF-8 
+          encoding.
         </p>
 
         <ol class="algorithm">
           <li>
-Let <var>output</var> be a copy of <var>unsecuredDocument</var> and 
-<var>proof_list</var> be an empty list.
+Let <var>proof</var> be set to <var>securedDocument</var>.<var>proof</var>. Let 
+<var>proof_list</var> be an empty list. If <var>proof</var> is a list copy all 
+the elements of <var>proof</var> to <var>proof_list</var>. If <var>proof</var> 
+is an object add a copy of that object to <var>proof_list</var>.
           </li>
           <li>
-For each <var>options</var> in <var>options_list</var> run steps 2 through 8 of
-the algorithm in section <a href="#add-proof"></a>. If no exceptions are raised 
-append the generated <var>proof</var> value to the <var>proof_list</var> 
-otherwise raise the exception.
+Let the <var>unsecuredDocument</var> be a copy of the <var>securedDocument</var> 
+with the <var>proof</var> attribute removed. Let <var>output</var> be a copy of 
+the <var>unsecuredDocument</var>.
+          </li>
+          <li>
+If <var>options</var> contains a <code>previousProof</code> attribute check if 
+an element of the <var>proof_list</var> has a matching <code>id</code> attribute. 
+If not  a `PROOF_GENERATION_ERROR` MUST be raised.
+          </li>
+          <li>
+Run steps 2 through 8 of the algorithm in section <a href="#add-proof"></a>. If 
+no exceptions are raised append the generated <var>proof</var> value to the 
+<var>proof_list</var> otherwise raise the exception.
           </li>
           <li>
 Set <var>output</var>.<var>proof</var> to the value of <var>proof_list</var>.
           </li>
           <li>
-Return <var>output</var> as the <a>secured data document</a>.
+Return <var>output</var> as the new <a>secured data document</a>.
           </li>
         </ol>
       </section>
-      <section>
-        <h3>Add Proof Chain</h3>
-        <p>
-          The following algorithm specifies how to add a proof chain to a 
-          document. Required inputs are an
-          <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
-          (unordered) list of
-          <a>proof options</a> (<var>options_list</var>) to which an order will
-          be established. Each <a>proof options</a>
-          (<var>options</var>) in the list must satisfy the criteria in 
-          section <a href="#add-proof"></a>.
-          A <dfn>secured data document</dfn> is produced as
-          output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
-        </p>
-
-        <ol class="algorithm">
-          <li>
-For each <var>options</var> in <var>options_list</var> that represents a proof 
-that must come before another proof add an <code>id</code> attribute if it is 
-not already present.
-          </li>
-          <li>
-For each <var>options</var> in <var>options_list</var> that represents a proof 
-that must come after another proof add an <code>previousProof</code> attribute 
-with value the <code>id</code> of the proof that must come before it.
-not already present.
-          </li>
-          <li>
-Use this modified <var>options_list</var> in the algorithm of section 
-<a href="#add-proof-set"></a>.
-          </li>
-        </ol>        
-      </section>
+      
       <section>
         <h3>Verify Proof</h3>
 
@@ -1846,8 +1827,7 @@ In the case of a proof set or proof chain a <a>secured data document</a> has a
 The following algorithm specifies how to check the authenticity and
 integrity of a <a>secured data document</a> by verifying each
 proof in the <var>proof_list</var>. Required inputs are a
-<a>secured data document</a> (<var>securedDocument</var>) and
-<a>proof options</a> (<var>options</var>). A list of 
+<a>secured data document</a> (<var>securedDocument</var>). A list of 
 verification results is produced as output.
         </p>
         <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -1697,7 +1697,7 @@ via the digital proof.
           The following algorithm specifies how to add a proof set to a 
           document. Required inputs are an
           <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
-          (unordered) list of
+          list (unordered) of
           <a>proof options</a> (<var>options_list</var>). Each <a>proof options</a>
           (<var>options</var>) in the list must satisfy the criteria in 
           section <a href="#add-proof"></a>.

--- a/index.html
+++ b/index.html
@@ -1691,7 +1691,72 @@ via the digital proof.
         </p>
 
       </section>
+      <section>
+        <h3>Add Proof Set</h3>
+        <p>
+          The following algorithm specifies how to add a proof set to a 
+          document. Required inputs are an
+          <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
+          (unordered) list of
+          <a>proof options</a> (<var>options_list</var>). Each <a>proof options</a>
+          (<var>options</var>) in the list must satisfy the criteria in 
+          section <a href="#add-proof"></a>.
+          A <dfn>secured data document</dfn> is produced as
+          output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
+        </p>
 
+        <ol class="algorithm">
+          <li>
+Let <var>output</var> be a copy of <var>unsecuredDocument</var> and 
+<var>proof_list</var> be an empty list.
+          </li>
+          <li>
+For each <var>options</var> in <var>options_list</var> run steps 2 through 8 of
+the algorithm in section <a href="#add-proof"></a>. If no exceptions are raised 
+append the generated <var>proof</var> value to the <var>proof_list</var> 
+otherwise raise the exception.
+          </li>
+          <li>
+Set <var>output</var>.<var>proof</var> to the value of <var>proof_list</var>.
+          </li>
+          <li>
+Return <var>output</var> as the <a>secured data document</a>.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h3>Add Proof Chain</h3>
+        <p>
+          The following algorithm specifies how to add a proof chain to a 
+          document. Required inputs are an
+          <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
+          (unordered) list of
+          <a>proof options</a> (<var>options_list</var>) to which an order will
+          be established. Each <a>proof options</a>
+          (<var>options</var>) in the list must satisfy the criteria in 
+          section <a href="#add-proof"></a>.
+          A <dfn>secured data document</dfn> is produced as
+          output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
+        </p>
+
+        <ol class="algorithm">
+          <li>
+For each <var>options</var> in <var>options_list</var> that represents a proof 
+that must come before another proof add an <code>id</code> attribute if it is 
+not already present.
+          </li>
+          <li>
+For each <var>options</var> in <var>options_list</var> that represents a proof 
+that must come after another proof add an <code>previousProof</code> attribute 
+with value the <code>id</code> of the proof that must come before it.
+not already present.
+          </li>
+          <li>
+Use this modified <var>options_list</var> in the algorithm of section 
+<a href="#add-proof-set"></a>.
+          </li>
+        </ol>        
+      </section>
       <section>
         <h3>Verify Proof</h3>
 
@@ -1771,6 +1836,41 @@ Return <var>isProofVerified</var> as the <a>verification result</a>.
           </li>
         </ol>
 
+      </section>
+      <section>
+        <h3>Verify Proof Sets and Chains</h3>
+        <p>
+In the case of a proof set or proof chain a <a>secured data document</a> has a 
+<code>proof</code> attribute which contains a list of proofs 
+(<var>proof_list</var>).
+The following algorithm specifies how to check the authenticity and
+integrity of a <a>secured data document</a> by verifying each
+proof in the <var>proof_list</var>. Required inputs are a
+<a>secured data document</a> (<var>securedDocument</var>) and
+<a>proof options</a> (<var>options</var>). A list of 
+verification results is produced as output.
+        </p>
+        <ol class="algorithm">
+          <li>
+Set <var>proof_list</var> to </var><var>securedDocument</var>.<var>proof</var>. 
+          </li>
+          <li>
+For each <var>proof</var> in <var>proof_list</var> run steps 2-11 of the algorithm in
+section <a href="verify-proof"></a> and if no exceptions are raised, associate
+the <var>isProofVerified</var> value with this <var>proof</var>.
+          </li>
+          <li>
+For each <var>proof</var> in <var>proof_list</var> that contains a 
+<code>previousProof</code> attribute modify the associated 
+<var>isProofVerified</var> by iteratively checking that the proof identified by
+the <code>id</code> value in <var>previousProof</var> is valid along with any 
+<code>previousProofs</code> up the chain.
+          </li>
+          <li>
+Return the <var>proof_list</var> along with each proofs associated 
+<var>isProofVerified</var> information.
+          </li>
+        </ol>
       </section>
 
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -1726,8 +1726,8 @@ If not  a `PROOF_GENERATION_ERROR` MUST be raised.
           </li>
           <li>
 Run steps 2 through 8 of the algorithm in section <a href="#add-proof"></a>. If 
-no exceptions are raised append the generated <var>proof</var> value to the 
-<var>proof_list</var> otherwise raise the exception.
+no exceptions are raised, append the generated <var>proof</var> value to the 
+<var>proof_list</var>; otherwise, raise the exception.
           </li>
           <li>
 Set <var>output</var>.<var>proof</var> to the value of <var>proof_list</var>.


### PR DESCRIPTION
These additions address issue https://github.com/w3c/vc-data-integrity/issues/18 and provides text to specify the *add proof set*, *add proof chain*, and *verify proof sets and chains* algorithms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/121.html" title="Last updated on Jul 28, 2023, 9:06 PM UTC (1c98f16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/121/7f07983...Wind4Greg:1c98f16.html" title="Last updated on Jul 28, 2023, 9:06 PM UTC (1c98f16)">Diff</a>