### PR TITLE
Add creator generated nonce to proof.

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,7 +530,7 @@ in Section <a href="#proof-chains"></a>.
           <dt>nonce</dt>
           <dd>
 An OPTIONAL string value supplied by the proof creator. An example use of this 
-field is to increase privacy by increasing unlinkability to deterministically 
+field is to increase privacy by decreasing linkability to deterministically 
 generated signatures.
           </dd>
 

--- a/index.html
+++ b/index.html
@@ -530,8 +530,8 @@ in Section <a href="#proof-chains"></a>.
           <dt>nonce</dt>
           <dd>
 An OPTIONAL string value supplied by the proof creator. An example use of this 
-field is to increase privacy by decreasing linkability to deterministically 
-generated signatures.
+field is to increase privacy by decreasing linkability that is the result
+of deterministically generated signatures.
           </dd>
 
         </dl>

--- a/index.html
+++ b/index.html
@@ -527,6 +527,13 @@ that MUST verify before the current proof is processed. This property is used
 in Section <a href="#proof-chains"></a>.
           </dd>
 
+          <dt>nonce</dt>
+          <dd>
+An OPTIONAL string value supplied by the proof creator. An example use of this 
+field is to increase privacy by increasing unlinkability to deterministically 
+generated signatures.
+          </dd>
+
         </dl>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -529,7 +529,7 @@ in Section <a href="#proof-chains"></a>.
 
           <dt>nonce</dt>
           <dd>
-An OPTIONAL string value supplied by the proof creator. An example use of this 
+An OPTIONAL string value supplied by the proof creator. One use of this 
 field is to increase privacy by decreasing linkability that is the result
 of deterministically generated signatures.
           </dd>


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-data-integrity/issues/114. By adding the optional `nonce` attribute to a **proof** and providing some explanatory text.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/122.html" title="Last updated on Jul 25, 2023, 12:29 AM UTC (04ce3d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/122/7f07983...Wind4Greg:04ce3d6.html" title="Last updated on Jul 25, 2023, 12:29 AM UTC (04ce3d6)">Diff</a>