### PR TITLE
Add expires proof attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,6 +490,12 @@ The date and time the proof was created MUST be specified as an
 [[XMLSCHEMA11-2]] combined date and time string.
           </dd>
 
+          <dt>expires</dt>
+          <dd>
+The date and time the proof expires SHOULD be included and, if included, MUST be
+specified as an [[XMLSCHEMA11-2]] combined date and time string.
+          </dd>
+
           <dt>domain</dt>
           <dd>
 The creator of a proof SHOULD include a string value that indicates its intended usage, which a verifier SHOULD use to ensure the proof was intended to be used by them. The

--- a/index.html
+++ b/index.html
@@ -492,7 +492,7 @@ The date and time the proof was created MUST be specified as an
 
           <dt>expires</dt>
           <dd>
-The date and time the proof expires SHOULD be included and, if included, MUST be
+An OPTIONAL property that conveys the date and time that a proof expires that MUST be
 specified as an [[XMLSCHEMA11-2]] combined date and time string.
           </dd>
 

--- a/index.html
+++ b/index.html
@@ -492,7 +492,7 @@ The date and time the proof was created MUST be specified as an
 
           <dt>expires</dt>
           <dd>
-An OPTIONAL property that conveys the date and time that a proof expires that MUST be
+An OPTIONAL property that conveys the date and time that a proof expires and that, if present, MUST be
 specified as an [[XMLSCHEMA11-2]] combined date and time string.
           </dd>
 


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-data-integrity/issues/78 by adding the `expires` attribute to the definition of the **proof**. Note that this term is already defined in the data integrity context.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/124.html" title="Last updated on Jul 25, 2023, 12:28 AM UTC (e0c87ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/124/7f07983...Wind4Greg:e0c87ed.html" title="Last updated on Jul 25, 2023, 12:28 AM UTC (e0c87ed)">Diff</a>