### PR TITLE
Add requirement for protection of terms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1535,7 +1535,7 @@ privacy considerations specific to the cryptographic suite.
         </li>
         <li>
 The JSON-LD context associated with the cryptographic suite MUST have its terms 
-protected from unsafe redefinition using the <code>@protected</code> keyword.
+protected from unsafe redefinition, by use of the <code>@protected</code> keyword.
         </li>
       </ul>
 

--- a/index.html
+++ b/index.html
@@ -1533,6 +1533,10 @@ security considerations specific to the cryptographic suite.
 The specification MUST contain a Privacy Considerations section detailing
 privacy considerations specific to the cryptographic suite.
         </li>
+        <li>
+The JSON-LD context associated with the cryptographic suite MUST have its terms 
+protected from unsafe redefinition using the <code>@protected</code> keyword.
+        </li>
       </ul>
 
       <p class="issue" title="Require interoperability report?">


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-data-integrity/issues/48 to add a requirement for protecting *terms* in cryptosuite definitions. In particular to use the `@protected` keyword to protect against redefinition of terms in JSON-LD *contexts*.

Note that this issue was assigned to me, but I'm not a JSON-LD expert. Feel free to modify text to increase precision or better reflect the intent of the issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/125.html" title="Last updated on Jul 24, 2023, 10:01 PM UTC (8925c4c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/125/7f07983...Wind4Greg:8925c4c.html" title="Last updated on Jul 24, 2023, 10:01 PM UTC (8925c4c)">Diff</a>