### PR TITLE
Data Integrity Cryptosuites naming convention update

### DIFF
--- a/index.html
+++ b/index.html
@@ -2072,7 +2072,7 @@ Although the [[DI-ECDSA]] is based on ECDSA digital signatures, supports the
 same two incompatible canonicalization approaches as [[DI-EDDSA]], and supports
 two different levels of security (128 bit and 192 bit) via two alternative sets
 of elliptic curves and hashes, it has only two cryptosuite names:
-<q>ecdsa-rdc-2019</q> and <q>ecdsa-jcs-2019</q>. The security level and corresponding 
+<q>ecdsa-rdfc-2019</q> and <q>ecdsa-jcs-2019</q>. The security level and corresponding 
 curves and hashes are determined from the multi-key format of the public key 
 used in validation.
         </p>

--- a/index.html
+++ b/index.html
@@ -2065,7 +2065,7 @@ approximate year that the suite was proposed.
 For example, the [[DI-EDDSA]] is based on EdDSA digital signatures, supports 
 two incompatible options based on canonicalization approaches, and was proposed 
 in roughly the year 2022, so it would have two different cryptosuite names: 
-<q>eddsa-rdc-2022</q> and <q>eddsa-jcs-2022</q>.
+<q>eddsa-rdfc-2022</q> and <q>eddsa-jcs-2022</q>.
         </p>
         <p>
 Although the [[DI-ECDSA]] is based on ECDSA digital signatures, supports the

--- a/index.html
+++ b/index.html
@@ -2040,6 +2040,45 @@ appropriate override flags.
       </section>
 
       <section>
+        <h3>Conventions for Naming Cryptography Suites</h3>
+        <p>
+Section <a href="#versioning-cryptography-suites"></a> emphasized the 
+importance of providing relatively easy to understand information concerning the
+timeliness of particular cryptographic suite. While section 
+<a href="#protecting-application-developers"></a> further emphasized minimizing 
+the number of options to be specified. Indeed section 
+<a href="#cryptographic-suites"></a> lists requirements for crytographic suites
+which include detailed specification of algorithm, transformation, hashing and 
+serialization. Hence the name of the cryptographic suite does not need to 
+include all this detail which implies the <em>parametric versioning</em> mentioned
+in section <a href="#versioning-cryptography-suites"></a> is not necessary or
+desirable.
+        </p>
+        <p>
+The recommended naming convention convention for cryptographic suites is a 
+string composed of a signature algorithm identifier, separated by a hyphen from 
+an option identifier (if the cryptosuite supports more than incompatible 
+implementation option), followed by a hyphen and then designation of the year 
+that the suite was approximately proposed.
+        </p>
+        <p>
+For example the [[DI-EDDSA]] is based on EdDSA digital signatures and supports 
+two incompatible options based on canonicalization approaches, and was proposed 
+roughly in the year 2022 would have two different cryptosuite names: 
+<q>eddsa-rdc-2022</q> and <q>eddsa-jcs-2022</q>.
+        </p>
+        <p>
+Although the [[DI-ECDSA]] is based on ECDSA digital signatures, supports the 
+same two incompatible canonicalization approaches as [[DI-EDDSA]], and supports 
+two different levels of security (128 bit and 192 bit) via two alternative sets 
+of elliptic curves and hashes only cryptosuite names <q>ecdsa-rdc-2019</q> and 
+<q>ecdsa-jcs-2019</q>. The determination of the security level and corresponding 
+curves and hashes are determined from the multi-key format of the public key 
+used in validation.
+        </p>
+      </section>
+
+      <section>
         <h3>Agility and Layering</h3>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -2055,11 +2055,11 @@ in section <a href="#versioning-cryptography-suites"></a> is neither necessary n
 desirable.
         </p>
         <p>
-The recommended naming convention convention for cryptographic suites is a 
-string composed of a signature algorithm identifier, separated by a hyphen from 
-an option identifier (if the cryptosuite supports more than incompatible 
-implementation option), followed by a hyphen and then designation of the year 
-that the suite was approximately proposed.
+The recommended naming convention convention for cryptographic suites is a
+string composed of a signature algorithm identifier, separated by a hyphen from
+an option identifier (if the cryptosuite supports more than incompatible
+implementation options), followed by a hyphen and designation of the
+approximate year that the suite was proposed.
         </p>
         <p>
 For example the [[DI-EDDSA]] is based on EdDSA digital signatures and supports 

--- a/index.html
+++ b/index.html
@@ -2055,7 +2055,7 @@ in section <a href="#versioning-cryptography-suites"></a> is neither necessary n
 desirable.
         </p>
         <p>
-The recommended naming convention convention for cryptographic suites is a
+The recommended naming convention for cryptographic suites is a
 string composed of a signature algorithm identifier, separated by a hyphen from
 an option identifier (if the cryptosuite supports incompatible
 implementation options), followed by a hyphen and designation of the

--- a/index.html
+++ b/index.html
@@ -2046,12 +2046,12 @@ Section <a href="#versioning-cryptography-suites"></a> emphasized the
 importance of providing relatively easy to understand information concerning the
 timeliness of particular cryptographic suite, while section 
 <a href="#protecting-application-developers"></a> further emphasized minimizing 
-the number of options to be specified. Indeed section 
-<a href="#cryptographic-suites"></a> lists requirements for crytographic suites
-which include detailed specification of algorithm, transformation, hashing and 
-serialization. Hence the name of the cryptographic suite does not need to 
-include all this detail which implies the <em>parametric versioning</em> mentioned
-in section <a href="#versioning-cryptography-suites"></a> is not necessary or
+the number of options to be specified. Indeed, section 
+<a href="#cryptographic-suites"></a> lists requirements for cryptographic suites
+which include detailed specification of algorithm, transformation, hashing, and 
+serialization. Hence, the name of the cryptographic suite does not need to 
+include all this detail, which implies the <em>parametric versioning</em> mentioned
+in section <a href="#versioning-cryptography-suites"></a> is neither necessary nor
 desirable.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -2044,7 +2044,7 @@ appropriate override flags.
         <p>
 Section <a href="#versioning-cryptography-suites"></a> emphasized the 
 importance of providing relatively easy to understand information concerning the
-timeliness of particular cryptographic suite. While section 
+timeliness of particular cryptographic suite, while section 
 <a href="#protecting-application-developers"></a> further emphasized minimizing 
 the number of options to be specified. Indeed section 
 <a href="#cryptographic-suites"></a> lists requirements for crytographic suites

--- a/index.html
+++ b/index.html
@@ -2062,9 +2062,9 @@ implementation options), followed by a hyphen and designation of the
 approximate year that the suite was proposed.
         </p>
         <p>
-For example the [[DI-EDDSA]] is based on EdDSA digital signatures and supports 
+For example, the [[DI-EDDSA]] is based on EdDSA digital signatures, supports 
 two incompatible options based on canonicalization approaches, and was proposed 
-roughly in the year 2022 would have two different cryptosuite names: 
+in roughly the year 2022, so it would have two different cryptosuite names: 
 <q>eddsa-rdc-2022</q> and <q>eddsa-jcs-2022</q>.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -2068,11 +2068,11 @@ in roughly the year 2022, so it would have two different cryptosuite names:
 <q>eddsa-rdc-2022</q> and <q>eddsa-jcs-2022</q>.
         </p>
         <p>
-Although the [[DI-ECDSA]] is based on ECDSA digital signatures, supports the 
-same two incompatible canonicalization approaches as [[DI-EDDSA]], and supports 
-two different levels of security (128 bit and 192 bit) via two alternative sets 
-of elliptic curves and hashes only cryptosuite names <q>ecdsa-rdc-2019</q> and 
-<q>ecdsa-jcs-2019</q>. The determination of the security level and corresponding 
+Although the [[DI-ECDSA]] is based on ECDSA digital signatures, supports the
+same two incompatible canonicalization approaches as [[DI-EDDSA]], and supports
+two different levels of security (128 bit and 192 bit) via two alternative sets
+of elliptic curves and hashes, it has only two cryptosuite names:
+<q>ecdsa-rdc-2019</q> and <q>ecdsa-jcs-2019</q>. The security level and corresponding 
 curves and hashes are determined from the multi-key format of the public key 
 used in validation.
         </p>

--- a/index.html
+++ b/index.html
@@ -2057,7 +2057,7 @@ desirable.
         <p>
 The recommended naming convention convention for cryptographic suites is a
 string composed of a signature algorithm identifier, separated by a hyphen from
-an option identifier (if the cryptosuite supports more than incompatible
+an option identifier (if the cryptosuite supports incompatible
 implementation options), followed by a hyphen and designation of the
 approximate year that the suite was proposed.
         </p>


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-data-integrity/issues/38 on ciphersuite (cryptosuite) naming conventions. First there is the decision of where this text should go. I chose this location after section 5.1 Versioning Cryptography Suites,, and section 5.2 Protecting Application Developers since these sections along with the cryptographic suite requirements in section 3 actually justify the version/naming choices.

Second, the choice of naming convention reflects the discussions on issue https://github.com/w3c/vc-data-integrity/issues/38.  The choices made here impacts the EdDSA and ECDSA crypto suite text and test vector contained within them so we would like to nail this down sooner than later. Text improvements are welcome.

Cheers Greg B.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/126.html" title="Last updated on Jul 25, 2023, 12:26 AM UTC (7b10ec2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/126/7f07983...Wind4Greg:7b10ec2.html" title="Last updated on Jul 25, 2023, 12:26 AM UTC (7b10ec2)">Diff</a>