### PR TITLE
Require cryptosuite specifications to mitigate against poison graphs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2138,13 +2138,13 @@ and read from application storage.
         <p class="advisement">
 Some transformations, such as RDF Dataset Canonicalization [[RDF-CANON]], have
 mitigations for input data sets that can be used by attackers to consume
-excessive processing cycles. These class of attacks are called
-<a data-cite="RDF-CANON#dataset-poisoning">dataset poisoning</a> and all modern
+excessive processing cycles. This class of attack is called
+<a data-cite="RDF-CANON#dataset-poisoning">dataset poisoning</a>, and all modern
 RDF Dataset canonicalizers are required to detect these sorts of bad inputs and
-halt processing. The test suites for RDF Dataset Canonicalization contains such
+halt processing. The test suites for RDF Dataset Canonicalization includes such
 poisoned datasets to ensure that such mitigations exist in all conforming
 implementations. Generally speaking, cryptographic suite specifications that
-utilize transformations are required to mitigate these sorts of attacks and
+use transformations are required to mitigate these sorts of attacks, and
 implementers are urged to ensure that the software libraries that they use
 enforce these mitigations. These attacks are in the same general category as
 any resource starvation attack, such as HTTP clients that deliberately

--- a/index.html
+++ b/index.html
@@ -2131,6 +2131,23 @@ being protected. Developers are also urged to regularly confirm that the
 cryptographically protected data has not been tampered with as it is written to
 and read from application storage.
         </p>
+        <p class="advisement">
+Some transformations, such as RDF Dataset Canonicalization [[RDF-CANON]], have
+mitigations for input data sets that can be used by attackers to consume
+excessive processing cycles. These class of attacks are called
+<a data-cite="RDF-CANON#dataset-poisoning">dataset poisoning</a> and all modern
+RDF Dataset canonicalizers are required to detect these sorts of bad inputs and
+halt processing. The test suites for RDF Dataset Canonicalization contains such
+poisoned datasets to ensure that such mitigations exist in all conforming
+implementations. Generally speaking, cryptographic suite specifications that
+utilize transformations are required to mitigate these sorts of attacks and
+implementers are urged to ensure that the software libraries that they use
+enforce these mitigations. These attacks are in the same general category as
+any resource starvation attack, such as HTTP clients that deliberately
+slow connections, thus starving connections on the server. Implementers are
+advised to consider these sorts of attacks when implementing defensive
+security strategies.
+        </p>
         <p class="issue"
           title="Collision-resistant canonicalization requirements">
 The VCWG is seeking feedback on normative language that cryptographic suite

--- a/index.html
+++ b/index.html
@@ -1532,6 +1532,10 @@ parameters, and other necessary details used to perform cryptographic
 verification of the data.
         </li>
         <li>
+The specification MUST detail any known resource starvation attack that can
+occur in an algorithm and provide testable mitigations against each attack.
+        </li>
+        <li>
 The specification MUST contain a Security Considerations section detailing
 security considerations specific to the cryptographic suite.
         </li>


### PR DESCRIPTION
This PR attempts to address issue #87 by 1) documenting that some transformations (like RDF Dataset Canonicalization) can be attacked, and 2) that there are mitigations for those attacks and cryptosuite specifications MUST ensure that those mitigations are implemented.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/128.html" title="Last updated on Jul 29, 2023, 6:08 PM UTC (d6bb627)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/128/1272e58...d6bb627.html" title="Last updated on Jul 29, 2023, 6:08 PM UTC (d6bb627)">Diff</a>