### PR TITLE
Clarify how proof types (and terms) are mapped to URLs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,24 +444,34 @@ The vocabulary where these URLs are defined is the [[?SECURITY-VOCABULARY]]. The
 explicit mechanism that is used to perform this mapping in a secured document is
 the `@context` property.
       </p>
+
       <p>
-When processing a document in a JSON-LD environment, the mapping mechanism is
-defined by JSON-LD [[JSON-LD11]]. When processing a document in a non-JSON-LD
-environment, the same mechanism is used to ensure that the terms have the same
-interpretation regardless of format, but with a simpler processing rule:
+When a JSON-LD processor is used, the mapping mechanism is defined by JSON-LD
+[[JSON-LD11]]. When a non-JSON-LD processor is used, the same mechanism is used
+to ensure that the terms have the same interpretation regardless of format.
       </p>
 
       <p>
-Ensure that all values associated with a `@context` property are in the expected
-order, the context files match documented cryptographic hashes for each file,
-and domain experts have deemed that the contents of each file are appropriate
-for the intended use case.
+When a document is expected to be processed by a non-JSON-LD processor,
+document authors are advised to ensure that domain experts have 1) specified the
+expected order for all values associated with a `@context` property, 2)
+published cryptographic hashes for each `@context` file, and 3) deemed that the
+contents of each `@context` file are appropriate for the intended use case.
       </p>
 
       <p>
-Using static context files with a JSON Schema is one acceptable approach to
-implementing the rule described above, ensuring proper term identification,
-typing, and order, when a non-JSON-LD processor is used.
+When a document is processed by a non-JSON-LD processor and there is a
+requirement to use the same semantics as those used in a JSON-LD environment,
+implementers are advised to 1) enforce the expected order and values in the
+`@context` property, and 2) ensure that each `@context` file matches the known
+cryptographic hashes for each `@context` file.
+      </p>
+
+      <p>
+Using static, versioned `@context` files with published cryptographic hashes in
+conjunction with JSON Schema is one acceptable approach to implementing the
+mechanisms described above, which ensures proper term identification, typing,
+and order, when a non-JSON-LD processor is used.
       </p>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -446,17 +446,12 @@ the `@context` property.
       </p>
 
       <p>
-When a JSON-LD processor is used, the mapping mechanism is defined by JSON-LD
-[[JSON-LD11]]. When a non-JSON-LD processor is used, the same mechanism is used
-to ensure that the terms have the same interpretation regardless of format.
-      </p>
-
-      <p>
-When a document is expected to be processed by a non-JSON-LD processor,
-document authors are advised to ensure that domain experts have 1) specified the
-expected order for all values associated with a `@context` property, 2)
-published cryptographic hashes for each `@context` file, and 3) deemed that the
-contents of each `@context` file are appropriate for the intended use case.
+The mapping mechanism is defined by JSON-LD [[JSON-LD11]]. To ensure a document
+can be interoperably consumed without the use of a JSON-LD library, document authors
+are advised to ensure that domain experts have 1) specified the expected order for
+all values associated with a `@context` property, 2) published cryptographic hashes
+for each `@context` file, and 3) deemed that the contents of each `@context` file
+are appropriate for the intended use case.
       </p>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -459,15 +459,6 @@ for the intended use case.
       </p>
 
       <p>
-If no `@context` value is specified in a secured document, implementations MUST
-assume a `@context` value of `https://w3id.org/security/data-integrity/v1` at
-the top-level of the document being secured. Specifications MAY specify a
-different default `@context` value, and if provided, the specification MUST
-document a way of identifying when the different default `@context` value can be
-assumed (such as through a version or type identifier).
-      </p>
-
-      <p>
 Using static context files with a JSON Schema is one acceptable approach to
 implementing the rule described above, ensuring proper term identification,
 typing, and order, when a non-JSON-LD processor is used.

--- a/index.html
+++ b/index.html
@@ -438,6 +438,27 @@ This section specifies the data model that is used for expressing
 <a>verification methods</a>.
       </p>
 
+      <p>
+All of the data model terms and types in this specification map to URLs. The
+vocabulary where these terms are defined is the [[?SECURITY-VOCABULARY]]. The
+explicit mechanism that is used to perform this mapping in a secured document
+is the `@context` property.
+      </p>
+      <p>
+When processing a document as JSON-LD, the mapping mechanism is defined by
+JSON-LD [[JSON-LD11]]. When processing a document in a non-JSON-LD environment,
+the same mechanism is used to ensure that the terms have the same interpretation
+regardless of format, but with a simpler processing rule: Implementers
+performing non-JSON-LD processing MUST ensure that all values associated with a
+`@context` property are in the expected order, the contents of the context files
+match known good cryptographic hashes for each file, and the contents are known
+to be valid. Implicit `@context` values MAY be used such that no `@context`
+value needs to be present in a non-JSON-LD document. Using static context files
+with a JSON Schema is one acceptable approach to implementing the aforementioned
+rule above. This can ensure proper term identification, typing, and order, when
+a non-JSON-LD processor is used.
+      </p>
+
       <section>
         <h3>Proofs</h3>
         <p>
@@ -547,11 +568,6 @@ of deterministically generated signatures.
           </dd>
 
         </dl>
-
-        <p class="note">
-All of the terms above map to URLs. The vocabulary where these terms are defined
-is the [[?SECURITY-VOCABULARY]].
-        </p>
 
         <p>
 A proof can be added to a JSON document like the following:
@@ -1608,7 +1624,7 @@ the data returned depends on HTTP content negotiation. These are as follows:
 application/ld+json
               </td>
               <td>
-The vocabulary in JSON-LD format [[?JSON-LD]].<br><br>
+The vocabulary in JSON-LD format [[?JSON-LD11]].<br><br>
 
 sha256: LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=<br><br>
 

--- a/index.html
+++ b/index.html
@@ -445,18 +445,25 @@ explicit mechanism that is used to perform this mapping in a secured document
 is the `@context` property.
       </p>
       <p>
-When processing a document in a JSON-LD environment, the mapping mechanism is defined by
-JSON-LD [[JSON-LD11]]. When processing a document in a non-JSON-LD environment,
-the same mechanism is used to ensure that the terms have the same interpretation
-regardless of format, but with a simpler processing rule: Implementers
-performing non-JSON-LD processing MUST ensure that all values associated with an
-`@context` property are in the expected order, the contents of the context files
-match known good cryptographic hashes for each file, and the contents are known
-to be valid. Implicit `@context` values MAY be used such that no `@context`
-value needs to be present in a non-JSON-LD document. Using static context files
-with a JSON Schema is one acceptable approach to implementing the rule
-described above, ensuring proper term identification, typing, and order, when
-a non-JSON-LD processor is used.
+When processing a document in a JSON-LD environment, the mapping mechanism is
+defined by JSON-LD [[JSON-LD11]]. When processing a document in a non-JSON-LD
+environment, the same mechanism is used to ensure that the terms have the same
+interpretation regardless of format, but with a simpler processing rule:
+      </p>
+
+      <p>
+Ensure that all values associated with a `@context` property are in the expected
+order, the contents of the context files match known good cryptographic hashes
+for each file, and domain experts have deemed that the contents are appropriate
+for the intended use case.
+      </p>
+
+      <p>
+Implicit `@context` values MAY be used such that no `@context` value needs to be
+present in a non-JSON-LD document. Using static context files with a JSON Schema
+is one acceptable approach to implementing the rule described above, ensuring
+proper term identification, typing, and order, when a non-JSON-LD processor is
+used.
       </p>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -439,10 +439,10 @@ This section specifies the data model that is used for expressing
       </p>
 
       <p>
-All of the data model terms and types in this specification map to URLs. The
-vocabulary where these URLs are defined is the [[?SECURITY-VOCABULARY]]. The
-explicit mechanism that is used to perform this mapping in a secured document
-is the `@context` property.
+All of the data model properties and types in this specification map to URLs.
+The vocabulary where these URLs are defined is the [[?SECURITY-VOCABULARY]]. The
+explicit mechanism that is used to perform this mapping in a secured document is
+the `@context` property.
       </p>
       <p>
 When processing a document in a JSON-LD environment, the mapping mechanism is
@@ -453,17 +453,24 @@ interpretation regardless of format, but with a simpler processing rule:
 
       <p>
 Ensure that all values associated with a `@context` property are in the expected
-order, the contents of the context files match known good cryptographic hashes
-for each file, and domain experts have deemed that the contents are appropriate
+order, the context files match documented cryptographic hashes for each file,
+and domain experts have deemed that the contents of each file are appropriate
 for the intended use case.
       </p>
 
       <p>
-Implicit `@context` values MAY be used such that no `@context` value needs to be
-present in a non-JSON-LD document. Using static context files with a JSON Schema
-is one acceptable approach to implementing the rule described above, ensuring
-proper term identification, typing, and order, when a non-JSON-LD processor is
-used.
+If no `@context` value is specified in a secured document, implementations MUST
+assume a `@context` value of `https://w3id.org/security/data-integrity/v1` at
+the top-level of the document being secured. Specifications MAY specify a
+different default `@context` value, and if provided, the specification MUST
+document a way of identifying when the different default `@context` value can be
+assumed (such as through a version or type identifier).
+      </p>
+
+      <p>
+Using static context files with a JSON Schema is one acceptable approach to
+implementing the rule described above, ensuring proper term identification,
+typing, and order, when a non-JSON-LD processor is used.
       </p>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -445,17 +445,17 @@ explicit mechanism that is used to perform this mapping in a secured document
 is the `@context` property.
       </p>
       <p>
-When processing a document as JSON-LD, the mapping mechanism is defined by
+When processing a document in a JSON-LD environment, the mapping mechanism is defined by
 JSON-LD [[JSON-LD11]]. When processing a document in a non-JSON-LD environment,
 the same mechanism is used to ensure that the terms have the same interpretation
 regardless of format, but with a simpler processing rule: Implementers
-performing non-JSON-LD processing MUST ensure that all values associated with a
+performing non-JSON-LD processing MUST ensure that all values associated with an
 `@context` property are in the expected order, the contents of the context files
 match known good cryptographic hashes for each file, and the contents are known
 to be valid. Implicit `@context` values MAY be used such that no `@context`
 value needs to be present in a non-JSON-LD document. Using static context files
-with a JSON Schema is one acceptable approach to implementing the aforementioned
-rule above. This can ensure proper term identification, typing, and order, when
+with a JSON Schema is one acceptable approach to implementing the rule
+described above, ensuring proper term identification, typing, and order, when
 a non-JSON-LD processor is used.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -440,7 +440,7 @@ This section specifies the data model that is used for expressing
 
       <p>
 All of the data model terms and types in this specification map to URLs. The
-vocabulary where these terms are defined is the [[?SECURITY-VOCABULARY]]. The
+vocabulary where these URLs are defined is the [[?SECURITY-VOCABULARY]]. The
 explicit mechanism that is used to perform this mapping in a secured document
 is the `@context` property.
       </p>


### PR DESCRIPTION
This PR addresses issue #60 by clarifying how proof types and terms are mapped to URLs in JSON-LD and non-JSON-LD environments.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/133.html" title="Last updated on Aug 6, 2023, 8:29 PM UTC (dc772c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/133/28a168f...dc772c9.html" title="Last updated on Aug 6, 2023, 8:29 PM UTC (dc772c9)">Diff</a>