### PR TITLE
Add JSON Web Key to specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,13 @@
               status:   "WD",
               publisher:  "W3C Verifiable Credentials Working Group"
             },
+            "JOSE-REGISTRIES": {
+              title:    "The JSON Object Signing and Encryption (JOSE) Registries",
+              href:     "https://www.iana.org/assignments/jose/jose.xhtml",
+              authors:  ["The Internet Assigned Numbers Authority"],
+              status:   "REC",
+              publisher:  "The Internet Assigned Numbers Authority"
+            },
             "SECURITY-VOCABULARY": {
               title:    "The Security Vocabulary",
               href:     "https://w3id.org/security",
@@ -157,7 +164,7 @@
               ],
               status: "ED",
               publisher: "W3C Verifiable Credentials Working Group"
-            },
+            }
           },
           postProcess: [restrictRefs],
           otherLinks: [{
@@ -1037,7 +1044,7 @@ both properties above is shown below.
       <span class="comment">...</span>
       "verificationMethod": [{
         "id": "did:example:123#_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A",
-        "type": "JsonWebKey2020", <span class="comment">// external (property value)</span>
+        "type": "JsonWebKey", <span class="comment">// external (property value)</span>
         "controller": "did:example:123",
         "publicKeyJwk": {
           "crv": "Ed25519", <span class="comment">// external (property name)</span>
@@ -1108,6 +1115,82 @@ which is the [[?MULTIBASE]] header that conveys that the binary data is
 base58-encoded using the Bitcoin base-encoding alphabet. The decoded binary data
 [[?MULTICODEC]] header is `0x1300`, which specifies that the remaining data
 is a 32-byte raw Ed25519 private key.
+            </p>
+
+          </section>
+
+          <section>
+            <h3>JsonWebKey</h3>
+            <p>
+The JSON Web Key data model is a specific type of <a>verification method</a>
+that utilizes the JWK specification [[RFC7517]] to encode key types into a
+set of parameters. To encode a JSON Web Key, the <a>verification method</a>
+`type` MUST be set to `JsonWebKey` and the `publicKeyJwk` value MUST be a
+valid JWK value as described in [[RFC7517]]. An example of a JSON Web Key is
+provided below:
+            </p>
+
+            <pre class="example nohighlight"
+              title="JSON Web Key encoding of a Ed25519 public key">
+{
+  "@context": ["https://w3id.org/security/jwk/v1"],
+  "id": "did:example:123456789abcdefghi#keys-1",
+  "type": "JsonWebKey",
+  "controller": "did:example:123456789abcdefghi",
+  "publicKeyJwk": {
+    "kty": "OKP",
+    "alg": "EdDSA"
+    "crv": "Ed25519",
+    "kid": "did:example:123456789abcdefghi#keys-1",
+    "x": "_1EiHquO2aUx9JARSu0P8jdYT_OVneYxYOnOMAmUcFI",
+  }
+}
+            </pre>
+
+            <p>
+In the example above, the `publicKeyJwk` value contains the JSON Web Key.
+The `kty` property encodes the key type of "OKP", which means
+"Octet string key pairs". The `alg` property identifies the algorithm intended
+for use with the public key. The `crv` property identifies the particular
+curve type of the public key. The `kid` property specifies how the public key
+might be referenced in software systems; if present, the value SHOULD match the
+`id` property of the encapsulating `JsonWebKey` object. Finally, the `x`
+property specifies the point on the Ed25519 curve that is associated with the
+public key.
+            </p>
+
+            <p>
+The `publicKeyJwk` property MUST NOT contain any property marked as
+"Private" in any registry contained in the JOSE Registries [[JOSE-REGISTRIES]].
+            </p>
+
+            <p>
+The JSON Web Key data model is also capable of encoding secret keys, sometimes
+referred to as <em>private keys</em>.
+            </p>
+
+            <pre class="example nohighlight"
+              title="JSON Web Key encoding of a Ed25519 secret key">
+{
+  "@context": ["https://w3id.org/security/jwk/v1"],
+  "id": "did:example:123456789abcdefghi#keys-1",
+  "type": "JsonWebKey",
+  "controller": "did:example:123456789abcdefghi",
+  "secretKeyJwk": {
+    "kty": "OKP",
+    "alg": "EdDSA"
+    "crv": "Ed25519",
+    "kid": "did:example:123456789abcdefghi#keys-1",
+    "d": "Q6JwjCUdThSnoxfXHSFt5C1nVFycY_ZpW7qVzK644_g",
+    "x": "_1EiHquO2aUx9JARSu0P8jdYT_OVneYxYOnOMAmUcFI",
+  }
+}
+            </pre>
+
+            <p>
+The example above is identical to the previous example, except that the
+information is stored in the `secretKeyJwk` property and its value encodes the
+private key value in the `d` property.
             </p>
 
           </section>

--- a/index.html
+++ b/index.html
@@ -1122,8 +1122,8 @@ is a 32-byte raw Ed25519 private key.
           <section>
             <h3>JsonWebKey</h3>
             <p>
-The JSON Web Key data model is a specific type of <a>verification method</a>
-that utilizes the JWK specification [[RFC7517]] to encode key types into a
+The JSON Web Key (JWK) data model is a specific type of <a>verification method</a>
+that uses the JWK specification [[RFC7517]] to encode key types into a
 set of parameters. To encode a JSON Web Key, the <a>verification method</a>
 `type` MUST be set to `JsonWebKey` and the `publicKeyJwk` value MUST be a
 valid JWK value as described in [[RFC7517]]. An example of a JSON Web Key is
@@ -1131,7 +1131,7 @@ provided below:
             </p>
 
             <pre class="example nohighlight"
-              title="JSON Web Key encoding of a Ed25519 public key">
+              title="JSON Web Key encoding of an Ed25519 public key">
 {
   "@context": ["https://www.w3.org/ns/security/jwk/v1"],
   "id": "did:example:123456789abcdefghi#key-1",
@@ -1153,7 +1153,7 @@ The `kty` property encodes the key type of "OKP", which means
 "Octet string key pairs". The `alg` property identifies the algorithm intended
 for use with the public key. The `crv` property identifies the particular
 curve type of the public key. The `kid` property specifies how the public key
-might be referenced in software systems; if present, the value SHOULD match the
+might be referenced in software systems; if present, the `kid` value SHOULD match the
 `id` property of the encapsulating `JsonWebKey` object. Finally, the `x`
 property specifies the point on the Ed25519 curve that is associated with the
 public key.
@@ -1165,12 +1165,12 @@ The `publicKeyJwk` property MUST NOT contain any property marked as
             </p>
 
             <p>
-The JSON Web Key data model is also capable of encoding secret keys, sometimes
+The JSON Web Key data model is also capable of encoding <em>secret keys</em>, sometimes
 referred to as <em>private keys</em>.
             </p>
 
             <pre class="example nohighlight"
-              title="JSON Web Key encoding of a Ed25519 secret key">
+              title="JSON Web Key encoding of an Ed25519 secret key">
 {
   "@context": ["https://www.w3.org/ns/security/jwk/v1"],
   "id": "did:example:123456789abcdefghi#key-1",
@@ -1188,9 +1188,11 @@ referred to as <em>private keys</em>.
             </pre>
 
             <p>
-The example above is identical to the previous example, except that the
-information is stored in the `secretKeyJwk` property and its value encodes the
-private key value in the `d` property.
+The private key example above is almost identical to the previous example of the
+public key, except that the information is stored in the `secretKeyJwk` property
+(rather than the `publicKeyJwk`), and the private key value is encoded in the `d`
+property thereof (alongside the `x` property, which still specifies the point on
+the Ed25519 curve that is associated with the public key).
             </p>
 
           </section>

--- a/index.html
+++ b/index.html
@@ -960,28 +960,25 @@ using the `<a>controller</a>` property at the highest level of the
 
             <p>
 Verification material is any information that is used by a process that applies
-a <a>verification method</a>. The `type` of a <a>verification
-method</a> is expected to be used to determine its compatibility with such
-processes. Examples of verification material properties are
-`publicKeyJwk` or `publicKeyMultibase`. A
-<a>cryptographic suite</a> specification is responsible for specifying the
-<a>verification method</a> `type` and its associated verification
-material. For example, see <a href="https://w3c-ccg.github.io/lds-jws2020/">JSON
-Web Signature 2020</a> and <a
-href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Signature 2020</a>.
-For all registered <a>verification method</a> types and associated verification
-material available for <a>controllers</a>, please see the Data Integrity
-Specification Registries [TBD - DIS-REGISTRIES].
+a <a>verification method</a>. The `type` of a <a>verification method</a> is
+expected to be used to determine its compatibility with such processes. Examples
+of verification material include `JsonWebKey` and `Multikey`.
+A <a>cryptographic suite</a> specification is responsible for specifying the
+<a>verification method</a> `type` and its associated verification material
+format. For examples, see
+<a href="https://www.w3.org/TR/vc-di-ecdsa/">the Data Integrity ECDSA
+Cryptosuites</a> and <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">
+the Data Integrity EdDSA Cryptosuites</a>. For a list of <a>verification
+method</a> types please see the [[?SECURITY-VOCABULARY]].
             </p>
 
             <p>
 To increase the likelihood of interoperable implementations, this specification
-limits the number of formats for expressing verification material in a <a>controller
-document</a>. The fewer formats that implementers have to
+limits the number of formats for expressing verification material in a
+<a>controller document</a>. The fewer formats that implementers have to
 implement, the more likely it will be that they will support all of them. This
 approach attempts to strike a delicate balance between ease of implementation
 and supporting formats that have historically had broad deployment.
-Two supported verification material properties are listed below:
             </p>
 
             <p>
@@ -992,8 +989,8 @@ properties for the same material. For example, expressing key material in a
             </p>
 
             <p>
-An example of a <a>controller document</a> containing <a>verification methods</a> using
-both properties above is shown below.
+An example of a <a>controller document</a> containing <a>verification
+methods</a> using both properties above is shown below.
             </p>
 
             <pre id="example-various-verification-method-types"

--- a/index.html
+++ b/index.html
@@ -963,7 +963,7 @@ Verification material is any information that is used by a process that applies
 a <a>verification method</a>. The `type` of a <a>verification
 method</a> is expected to be used to determine its compatibility with such
 processes. Examples of verification material properties are
-`<a>publicKeyJwk</a>` or `<a>publicKeyMultibase</a>`. A
+`publicKeyJwk` or `publicKeyMultibase`. A
 <a>cryptographic suite</a> specification is responsible for specifying the
 <a>verification method</a> `type` and its associated verification
 material. For example, see <a href="https://w3c-ccg.github.io/lds-jws2020/">JSON
@@ -983,25 +983,6 @@ approach attempts to strike a delicate balance between ease of implementation
 and supporting formats that have historically had broad deployment.
 Two supported verification material properties are listed below:
             </p>
-
-            <dl>
-              <dt><dfn>publicKeyMultibase</dfn></dt>
-              <dd>
-                <p>
-The `publicKeyMultibase` property is OPTIONAL. This feature is
-non-normative. If present, the value MUST be a <a
-data-cite="INFRA#string">string</a> representation of a [[MULTIBASE]] encoded
-public key.
-                </p>
-                <p class="advisement">
-Note that the [[?MULTIBASE]] specification is not yet a standard and is
-subject to change. There might be some use cases for this data format
-where `<b>public</b>KeyMultibase` is defined, to allow for
-expression of <a>public keys</a>, but `<b>private</b>KeyMultibase`
-is not defined, to protect against accidental leakage of secret keys.
-                </p>
-              </dd>
-          </dl>
 
             <p>
 A <a>verification method</a> MUST NOT contain multiple verification material
@@ -1051,11 +1032,29 @@ both properties above is shown below.
             <h3>Multikey</h3>
             <p>
 The Multikey data model is a specific type of <a>verification method</a> that
-utilizes the [[?MULTICODEC]] specification to encode key types into a single
-binary stream that is then encoded using the [[?MULTIBASE]] specification.
-To encode a Multikey, the <a>verification method</a> `type` MUST be set to
-`Multikey` and the `publicKeyMultibase` value MUST be a [[MULTIBASE]] encoded
-[[MULTICODEC]] value. An example of a Multikey is provided below:
+utilizes the [[MULTICODEC]] specification to encode key types into a single
+binary stream that is then encoded using the [[MULTIBASE]] specification.
+            </p>
+
+            <p>
+When specifing a `Multikey`, the object takes the following form:
+            </p>
+
+            <dl>
+              <dt>type</dt>
+              <dd>
+The `type` property MUST contain the string `Multikey`.
+              </dd>
+              <dt><dfn>publicKeyMultibase</dfn></dt>
+              <dd>
+The `publicKeyMultibase` property is OPTIONAL. If present, the value MUST be a
+[[MULTIBASE]] encoded [[MULTICODEC]] value.
+              </dd>
+
+            </dl>
+
+            <p>
+An example of a Multikey is provided below:
             </p>
 
             <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -969,7 +969,7 @@ format. For examples, see
 <a href="https://www.w3.org/TR/vc-di-ecdsa/">the Data Integrity ECDSA
 Cryptosuites</a> and <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">
 the Data Integrity EdDSA Cryptosuites</a>. For a list of <a>verification
-method</a> types please see the [[?SECURITY-VOCABULARY]].
+method</a> types, please see the [[?SECURITY-VOCABULARY]].
             </p>
 
             <p>
@@ -977,8 +977,8 @@ To increase the likelihood of interoperable implementations, this specification
 limits the number of formats for expressing verification material in a
 <a>controller document</a>. The fewer formats that implementers have to
 implement, the more likely it will be that they will support all of them. This
-approach attempts to strike a delicate balance between ease of implementation
-and supporting formats that have historically had broad deployment.
+approach attempts to strike a delicate balance between easing implementation
+and providing support for formats that have historically had broad deployment.
             </p>
 
             <p>
@@ -1044,12 +1044,12 @@ The value of the `type` property MUST contain the string `Multikey`.
               </dd>
               <dt><dfn class="lint-ignore">publicKeyMultibase</dfn></dt>
               <dd>
-The `publicKeyMultibase` property is OPTIONAL. If present, the value MUST be a
+The `publicKeyMultibase` property is OPTIONAL. If present, its value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
               </dd>
               <dt><dfn class="lint-ignore">secretKeyMultibase</dfn></dt>
               <dd>
-The `secretKeyMultibase` property is OPTIONAL. If present, the value MUST be a
+The `secretKeyMultibase` property is OPTIONAL. If present, its value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
               </dd>
             </dl>
@@ -1122,10 +1122,10 @@ The value of the `type` property MUST contain the string `JsonWebKey`.
               </dd>
               <dt><dfn class="lint-ignore">publicKeyJwk</dfn></dt>
               <dd>
-The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
+The `publicKeyJwk` property is OPTIONAL. If present, its value MUST
 be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
 conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
-include any members of the private information class, such as "d", as described
+include any members of the private information class, such as `d`, as described
 in the <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">JWK
 Registration Template</a>. It is RECOMMENDED that verification methods that use
 JWKs [[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as
@@ -1136,7 +1136,7 @@ public key with a compound key identifier.
               </dd>
               <dt><dfn class="lint-ignore">secretKeyJwk</dfn></dt>
               <dd>
-The `secretKeyJwk` property is OPTIONAL. If present, the value MUST be a <a
+The `secretKeyJwk` property is OPTIONAL. If present, its value MUST be a <a
 data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that conforms
 to [[RFC7517]].
               </dd>

--- a/index.html
+++ b/index.html
@@ -1094,8 +1094,8 @@ is a 32-byte raw Ed25519 <a>public key</a>.
             </p>
 
             <p>
-The Multikey data model is also capable of encoding secret keys, sometimes
-referred to as <em>private keys</em>.
+The Multikey data model is also capable of encoding secret keys, whose subtypes
+include <em>symmetric keys</em> and <em>private keys</em>.
             </p>
 
             <pre class="example nohighlight"
@@ -1125,9 +1125,9 @@ is a 32-byte raw Ed25519 private key.
 The JSON Web Key (JWK) data model is a specific type of <a>verification method</a>
 that uses the JWK specification [[RFC7517]] to encode key types into a
 set of parameters. To encode a JSON Web Key, the <a>verification method</a>
-`type` MUST be set to `JsonWebKey` and the `publicKeyJwk` value MUST be a
-valid JWK value as described in [[RFC7517]]. An example of a JSON Web Key is
-provided below:
+`type` MUST be set to `JsonWebKey` and the `publicKeyJwk` or `secretKeyJwk`
+value MUST be a valid JWK value as described in [[RFC7517]]. An example of a
+JSON Web Key is provided below:
             </p>
 
             <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -1050,7 +1050,11 @@ The `type` property MUST contain the string `Multikey`.
 The `publicKeyMultibase` property is OPTIONAL. If present, the value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
               </dd>
-
+              <dt><dfn>secretKeyMultibase</dfn></dt>
+              <dd>
+The `secretKeyMultibase` property is OPTIONAL. If present, the value MUST be a
+[[MULTIBASE]] encoded [[MULTICODEC]] value.
+              </dd>
             </dl>
 
             <p>

--- a/index.html
+++ b/index.html
@@ -1133,15 +1133,15 @@ provided below:
             <pre class="example nohighlight"
               title="JSON Web Key encoding of a Ed25519 public key">
 {
-  "@context": ["https://w3id.org/security/jwk/v1"],
-  "id": "did:example:123456789abcdefghi#keys-1",
+  "@context": ["https://www.w3.org/ns/security/jwk/v1"],
+  "id": "did:example:123456789abcdefghi#key-1",
   "type": "JsonWebKey",
   "controller": "did:example:123456789abcdefghi",
   "publicKeyJwk": {
     "kty": "OKP",
     "alg": "EdDSA"
     "crv": "Ed25519",
-    "kid": "did:example:123456789abcdefghi#keys-1",
+    "kid": "key-1",
     "x": "_1EiHquO2aUx9JARSu0P8jdYT_OVneYxYOnOMAmUcFI",
   }
 }
@@ -1172,15 +1172,15 @@ referred to as <em>private keys</em>.
             <pre class="example nohighlight"
               title="JSON Web Key encoding of a Ed25519 secret key">
 {
-  "@context": ["https://w3id.org/security/jwk/v1"],
-  "id": "did:example:123456789abcdefghi#keys-1",
+  "@context": [""https://www.w3.org/ns/security/jwk/v1""],
+  "id": "did:example:123456789abcdefghi#key-1",
   "type": "JsonWebKey",
   "controller": "did:example:123456789abcdefghi",
   "secretKeyJwk": {
     "kty": "OKP",
     "alg": "EdDSA"
     "crv": "Ed25519",
-    "kid": "did:example:123456789abcdefghi#keys-1",
+    "kid": "key-1",
     "d": "Q6JwjCUdThSnoxfXHSFt5C1nVFycY_ZpW7qVzK644_g",
     "x": "_1EiHquO2aUx9JARSu0P8jdYT_OVneYxYOnOMAmUcFI",
   }

--- a/index.html
+++ b/index.html
@@ -1045,12 +1045,12 @@ When specifing a `Multikey`, the object takes the following form:
               <dd>
 The `type` property MUST contain the string `Multikey`.
               </dd>
-              <dt><dfn>publicKeyMultibase</dfn></dt>
+              <dt><dfn class="lint-ignore">publicKeyMultibase</dfn></dt>
               <dd>
 The `publicKeyMultibase` property is OPTIONAL. If present, the value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
               </dd>
-              <dt><dfn>secretKeyMultibase</dfn></dt>
+              <dt><dfn class="lint-ignore">secretKeyMultibase</dfn></dt>
               <dd>
 The `secretKeyMultibase` property is OPTIONAL. If present, the value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
@@ -1123,7 +1123,7 @@ When specifing a `JsonWebKey`, the object takes the following form:
               <dd>
 The `type` property MUST contain the string `JsonWebKey`.
               </dd>
-              <dt id="publickeyjwk">publicKeyJwk</dt>
+              <dt><dfn class="lint-ignore">publicKeyJwk</dfn></dt>
               <dd>
 The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
 be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
@@ -1137,7 +1137,7 @@ the public key fingerprint [[RFC7638]]. See the first key in
 <a href="#example-various-verification-method-types"></a> for an example of a
 public key with a compound key identifier.
               </dd>
-              <dt id="secretkeyjwk">secretKeyJwk</dt>
+              <dt><dfn class="lint-ignore">secretKeyJwk</dfn></dt>
               <dd>
 The `secretKeyJwk` property is OPTIONAL. If present, the value MUST be a <a
 data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that conforms

--- a/index.html
+++ b/index.html
@@ -1125,7 +1125,7 @@ The `type` property MUST contain the string `JsonWebKey`.
 The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
 be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
 conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
-any members of the private information class, such as "d", as described
+include any members of the private information class, such as "d", as described
 in the <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">JWK
 Registration Template</a>. It is RECOMMENDED that verification methods that use
 JWKs [[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as

--- a/index.html
+++ b/index.html
@@ -1134,7 +1134,12 @@ the public key fingerprint [[RFC7638]]. See the first key in
 <a href="#example-various-verification-method-types"></a> for an example of a
 public key with a compound key identifier.
               </dd>
-
+              <dt id="secretkeyjwk">secretKeyJwk</dt>
+              <dd>
+The `secretKeyJwk` property is OPTIONAL. If present, the value MUST be a <a
+data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that conforms
+to [[RFC7517]].
+              </dd>
             </dl>
 
             <p>

--- a/index.html
+++ b/index.html
@@ -985,22 +985,6 @@ Two supported verification material properties are listed below:
             </p>
 
             <dl>
-              <dt><dfn>publicKeyJwk</dfn></dt>
-              <dd>
-                <p>
-The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
-be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
-conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
-contain "d", or any other members of the private information class as described
-in <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">Registration
-Template</a>. It is RECOMMENDED that verification methods that use JWKs
-[[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as
-their fragment identifier. It is RECOMMENDED that JWK
-`kid` values are set to the public key fingerprint [[RFC7638]]. See
-the first key in <a href="#example-various-verification-method-types"></a> for
-an example of a public key with a compound key identifier.
-                </p>
-              </dd>
               <dt><dfn>publicKeyMultibase</dfn></dt>
               <dd>
                 <p>
@@ -1124,10 +1108,37 @@ is a 32-byte raw Ed25519 private key.
             <p>
 The JSON Web Key (JWK) data model is a specific type of <a>verification method</a>
 that uses the JWK specification [[RFC7517]] to encode key types into a
-set of parameters. To encode a JSON Web Key, the <a>verification method</a>
-`type` MUST be set to `JsonWebKey` and the `publicKeyJwk` or `secretKeyJwk`
-value MUST be a valid JWK value as described in [[RFC7517]]. An example of a
-JSON Web Key is provided below:
+set of parameters.
+            </p>
+
+            <p>
+When specifing a `JsonWebKey`, the object takes the following form:
+            </p>
+
+            <dl>
+              <dt>type</dt>
+              <dd>
+The `type` property MUST contain the string `JsonWebKey`.
+              </dd>
+              <dt id="publickeyjwk">publicKeyJwk</dt>
+              <dd>
+The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
+be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
+conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
+any members of the private information class, such as "d", as described
+in the <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">JWK
+Registration Template</a>. It is RECOMMENDED that verification methods that use
+JWKs [[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as
+their fragment identifier. It is RECOMMENDED that JWK `kid` values are set to
+the public key fingerprint [[RFC7638]]. See the first key in
+<a href="#example-various-verification-method-types"></a> for an example of a
+public key with a compound key identifier.
+              </dd>
+
+            </dl>
+
+            <p>
+An example of an object that conforms to this data model is provided below:
             </p>
 
             <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
             },
             "JOSE-REGISTRIES": {
               title:    "The JSON Object Signing and Encryption (JOSE) Registries",
-              href:     "https://www.iana.org/assignments/jose/jose.xhtml",
+              href:     "https://www.iana.org/assignments/jose",
               authors:  ["The Internet Assigned Numbers Authority"],
               status:   "REC",
               publisher:  "The Internet Assigned Numbers Authority"

--- a/index.html
+++ b/index.html
@@ -1172,7 +1172,7 @@ referred to as <em>private keys</em>.
             <pre class="example nohighlight"
               title="JSON Web Key encoding of a Ed25519 secret key">
 {
-  "@context": [""https://www.w3.org/ns/security/jwk/v1""],
+  "@context": ["https://www.w3.org/ns/security/jwk/v1"],
   "id": "did:example:123456789abcdefghi#key-1",
   "type": "JsonWebKey",
   "controller": "did:example:123456789abcdefghi",

--- a/index.html
+++ b/index.html
@@ -962,7 +962,7 @@ using the `<a>controller</a>` property at the highest level of the
 Verification material is any information that is used by a process that applies
 a <a>verification method</a>. The `type` of a <a>verification method</a> is
 expected to be used to determine its compatibility with such processes. Examples
-of verification material include `JsonWebKey` and `Multikey`.
+of verification methods include `JsonWebKey` and `Multikey`.
 A <a>cryptographic suite</a> specification is responsible for specifying the
 <a>verification method</a> `type` and its associated verification material
 format. For examples, see
@@ -1040,7 +1040,7 @@ When specifing a `Multikey`, the object takes the following form:
             <dl>
               <dt>type</dt>
               <dd>
-The `type` property MUST contain the string `Multikey`.
+The value of the `type` property MUST contain the string `Multikey`.
               </dd>
               <dt><dfn class="lint-ignore">publicKeyMultibase</dfn></dt>
               <dd>
@@ -1118,7 +1118,7 @@ When specifing a `JsonWebKey`, the object takes the following form:
             <dl>
               <dt>type</dt>
               <dd>
-The `type` property MUST contain the string `JsonWebKey`.
+The value of the `type` property MUST contain the string `JsonWebKey`.
               </dd>
               <dt><dfn class="lint-ignore">publicKeyJwk</dfn></dt>
               <dd>

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -3,6 +3,8 @@ vocab:
   value: https://w3id.org/security#
 
 prefix:
+  - id: rdf
+    value: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   - id: cred
     value: https://w3.org/2018/credentials#
 
@@ -271,7 +273,7 @@ property:
 
   - id: publicKeyJwk
     label: Public key JWK
-    range: xsd:string
+    range: rdf:JSON
     domain: sec:VerificationMethod
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-publickeyjwk
     see_also:

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -245,7 +245,7 @@ property:
 
   - id: publicKeyMultibase
     label: Public key multibase
-    domain: sec:VerificationMethod
+    domain: sec:Multikey
     range: xsd:string
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-publickeymultibase
     see_also:
@@ -272,7 +272,7 @@ property:
   - id: publicKeyJwk
     label: Public key JWK
     range: rdf:JSON
-    domain: sec:VerificationMethod
+    domain: sec:JsonWebKey
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-publickeyjwk
     see_also:
       - label: IANA JOSE

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -43,6 +43,11 @@ class:
       - label: EdDSA Cryptosuite v2022
         url: https://www.w3.org/TR/vc-di-eddsa/#multikey
 
+  - id: JsonWebKey
+    label: JSON Web Key Verification Method
+    upper_value: sec:VerificationMethod
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#jsonwebkey
+
   - id: Key
     label: Cryptographic key
     comment: This class represents a cryptographic key that may be used for encryption, decryption, or digitally signing data. This class serves as a supertype for specific key types.

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -3,8 +3,6 @@ vocab:
   value: https://w3id.org/security#
 
 prefix:
-  - id: rdf
-    value: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   - id: cred
     value: https://w3.org/2018/credentials#
 


### PR DESCRIPTION
This PR addresses issue #130 and issue #73 by adding the `JsonWebKey` type to the specification and the vocabulary, and ensuring that the range of `publicKeyJwk` is JSON. This value was going to be defined in the JsonWebSignature2020 specification, but since that specification has been pulled, we have to define it somewhere else and the Data Integrity specification is probably the best place for it since it also defined controller documents and verification methods.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/135.html" title="Last updated on Aug 12, 2023, 7:26 PM UTC (1852514)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/135/b809599...1852514.html" title="Last updated on Aug 12, 2023, 7:26 PM UTC (1852514)">Diff</a>