### PR TITLE
Add section on context injection.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1655,6 +1655,33 @@ Credentials v2.0: Base Context</a> and <a data-cite="?VC-DATA-MODEL-2.0#vocabula
 Verifiable Credentials v2.0: Vocabularies</a>.
         </p>
 
+        <section>
+          <h3>Context Injection</h3>
+
+          <p>
+The `@context` property is used to ensure that implementations are using the
+same semantics when terms in this specification are processed. For example, this
+can be important when properties like `type` are processed and its value, such
+as `DataIntegrityProof`, are used.
+          </p>
+
+          <p>
+If a `@context` property is not provided in a document that is being secured or
+verified, or the Data Integrity terms used in the document are not defined by
+existing values in the `@context` property, implementations MUST inject or add
+an `@context` property with a value of
+`https://www.w3.org/ns/data-integrity/v1`.
+          </p>
+
+          <p>
+An example of when context injection is unnecessary is when the Verifiable
+Credential Data Model v2.0 context (`https://www.w3.org/ns/credentials/v2`)
+exists as a value in the `@context` property, as that context defines all of the
+necessary Data Integrity terms defined by
+`https://www.w3.org/ns/data-integrity/v1`.
+          </p>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1666,18 +1666,18 @@ as `DataIntegrityProof`, are used.
           </p>
 
           <p>
-If a `@context` property is not provided in a document that is being secured or
-verified, or the Data Integrity terms used in the document are not defined by
+If an `@context` property is not provided in a document that is being secured or
+verified, or the Data Integrity terms used in the document are not mapped by
 existing values in the `@context` property, implementations MUST inject or add
 an `@context` property with a value of
 `https://www.w3.org/ns/data-integrity/v1`.
           </p>
 
           <p>
-An example of when context injection is unnecessary is when the Verifiable
+One example of when context injection is expected to be unnecessary is when the Verifiable
 Credential Data Model v2.0 context (`https://www.w3.org/ns/credentials/v2`)
-exists as a value in the `@context` property, as that context defines all of the
-necessary Data Integrity terms defined by
+exists as a value in the `@context` property, as that context maps all of the
+necessary Data Integrity terms that were previously mapped by
 `https://www.w3.org/ns/data-integrity/v1`.
           </p>
         </section>


### PR DESCRIPTION
This PR attempts to address issue #88 by adding a section on context injection. This section ensures that all documents, whether they are processed as JSON or JSON-LD, end up using the same semantics for Data Integrity terms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/138.html" title="Last updated on Aug 5, 2023, 9:28 PM UTC (ea872a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/138/a665eb7...ea872a1.html" title="Last updated on Aug 5, 2023, 9:28 PM UTC (ea872a1)">Diff</a>