### PR TITLE
Add errors with anchors to the specification. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -2163,17 +2163,17 @@ The following example provides a minimum conformant
         <h3>Errors</h3>
 
         <p>
-The algorithms described in this specification, as well as cryptographic
+The algorithms described in this specification, as well as various cryptographic
 suite specitications, throw specific types of errors. Implementers might find
 it useful to convey these errors to other libraries or software systems. This
-section provides specific URLs, descriptions, and error codes for the errors
-such that the ecosystem implementing technologies described by this
+section provides specific URLs, descriptions, and error codes for the errors,
+such that an ecosystem implementing technologies described by this
 specification might interoperate more effectively when errors occur.
         </p>
 
         <p>
 When exposing these errors through an HTTP interface, implementers SHOULD use
-[[RFC7807]] to encode the error data structure. If [[RFC7807]] is utilized:
+[[RFC7807]] to encode the error data structure. If [[RFC7807]] is used:
         </p>
 
         <ul>
@@ -2184,7 +2184,7 @@ section listed below.
           </li>
           <li>
 The `code` value MUST be the integer code described in the table below
-(in parenthesis, beside the type name).
+(in parentheses, beside the type name).
           </li>
           <li>
 The `title` value SHOULD provide a short but specific human-readable string for

--- a/index.html
+++ b/index.html
@@ -2158,6 +2158,19 @@ The following example provides a minimum conformant
         </pre>
 
       </section>
+
+      <section class="normative">
+        <h3>Errors</h3>
+
+        <p>
+The algorithms described in this specification, as well as cryptographic
+suite specitications, throw specific types of errors. Implementers might find
+it useful to convey these errors to other libraries or software systems. This
+section provides specific URLs, descriptions, and error codes for the errors
+such that the ecosystem implementing technologies described by this
+specification might interoperate more effectively when errors occur.
+        </p>
+      </section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -2194,6 +2194,61 @@ the error.
 The `detail` value SHOULD provide a longer human-readable string for the error.
           </li>
         </ul>
+
+        <dl>
+          <dt id="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR (-16)</dt>
+          <dd>
+A request to generate a proof failed. See Section
+<a href="#add-proof"></a>, and Section <a href="#add-proof-set-chain"></a>.
+          </dd>
+          <dt id="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR (-17)</dt>
+          <dd>
+A proof that is malformed was detected. See Section
+<a href="#verify-proof"></a>.
+          </dd>
+          <dt id="#MISMATCHED_PROOF_PURPOSE_ERROR">MISMATCHED_PROOF_PURPOSE_ERROR (-18)</dt>
+          <dd>
+The `proofPurpose` value in a proof did not match the expected value. See
+Section <a href="#verify-proof"></a>.
+          </dd>
+          <dt id="#INVALID_DOMAIN_ERROR">INVALID_DOMAIN_ERROR (-19)</dt>
+          <dd>
+The `domain` value in a proof did not match the expected value. See Section
+<a href="#verify-proof"></a>.
+          </dd>
+          <dt id="#INVALID_CHALLENGE_ERROR">INVALID_CHALLENGE_ERROR (-20)</dt>
+          <dd>
+The `challenge` value in a proof did not match the expected value. See Section
+<a href="#verify-proof"></a>.
+          </dd>
+          <dt id="#INVALID_VERIFICATION_METHOD_URL">INVALID_VERIFICATION_METHOD_URL (-21)</dt>
+          <dd>
+The `verificationMethod` value in a proof was malformed. See Section
+<a href="#retrieve-verification-method"></a>.
+          </dd>
+          <dt id="#INVALID_CONTROLLER_DOCUMENT_ID">INVALID_CONTROLLER_DOCUMENT_ID (-22)</dt>
+          <dd>
+The `id` value in a <a>controller document</a> was malformed. See Section
+<a href="#retrieve-verification-method"></a>.
+          </dd>
+          <dt id="#INVALID_CONTROLLER_DOCUMENT">INVALID_CONTROLLER_DOCUMENT (-23)</dt>
+          <dd>
+The <a>controller document</a> was malformed. See Section
+<a href="#retrieve-verification-method"></a>.
+          </dd>
+          <dt id="#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD (-24)</dt>
+          <dd>
+The <a>verification method</a> in a <a>controller document</a> was malformed. See Section
+<a href="#retrieve-verification-method"></a>.
+          </dd>
+          <dt id="#INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD">INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD (-25)</dt>
+          <dd>
+The <a>verification method</a> in a <a>controller document</a> was not
+associated using the expected <a>verification relationship</a> as expressed
+in the `proofPurpose` property in the proof. See Section
+<a href="#retrieve-verification-method"></a>.
+          </dd>
+        </dl>
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -2170,6 +2170,30 @@ section provides specific URLs, descriptions, and error codes for the errors
 such that the ecosystem implementing technologies described by this
 specification might interoperate more effectively when errors occur.
         </p>
+
+        <p>
+When exposing these errors through an HTTP interface, implementers SHOULD use
+[[RFC7807]] to encode the error data structure. If [[RFC7807]] is utilized:
+        </p>
+
+        <ul>
+          <li>
+The `type` value of the error object MUST be a URL that starts with the value
+`https://www.w3.org/ns/security/data-integrity#` and ends with the value in the
+section listed below.
+          </li>
+          <li>
+The `code` value MUST be the integer code described in the table below
+(in parenthesis, beside the type name).
+          </li>
+          <li>
+The `title` value SHOULD provide a short but specific human-readable string for
+the error.
+          </li>
+          <li>
+The `detail` value SHOULD provide a longer human-readable string for the error.
+          </li>
+        </ul>
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -2163,8 +2163,8 @@ The following example provides a minimum conformant
         <h3>Errors</h3>
 
         <p>
-The algorithms described in this specification, as well as various cryptographic
-suite specitications, throw specific types of errors. Implementers might find
+The algorithms described in this specification, as well as in various cryptographic
+suite specifications, throw specific types of errors. Implementers might find
 it useful to convey these errors to other libraries or software systems. This
 section provides specific URLs, descriptions, and error codes for the errors,
 such that an ecosystem implementing technologies described by this

--- a/index.html
+++ b/index.html
@@ -2179,8 +2179,8 @@ When exposing these errors through an HTTP interface, implementers SHOULD use
         <ul>
           <li>
 The `type` value of the error object MUST be a URL that starts with the value
-`https://www.w3.org/ns/security/data-integrity#` and ends with the value in the
-section listed below.
+`https://w3id.org/security#` and ends with the value in the section listed
+below.
           </li>
           <li>
 The `code` value MUST be the integer code described in the table below


### PR DESCRIPTION
This PR is an attempt to address issue #136 by adding a table of error definitions to the specification with anchors that can be used by RFC 7807.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/140.html" title="Last updated on Aug 5, 2023, 9:40 PM UTC (9abc28c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/140/a665eb7...9abc28c.html" title="Last updated on Aug 5, 2023, 9:40 PM UTC (9abc28c)">Diff</a>