### PR TITLE
Added the error terms to the vocabulary

### DIFF
--- a/index.html
+++ b/index.html
@@ -2230,7 +2230,7 @@ The following example provides a minimum conformant
       </section>
 
       <section class="normative">
-        <h3>Errors</h3>
+        <h3>Processing Errors</h3>
 
         <p>
 The algorithms described in this specification, as well as in various cryptographic
@@ -2266,52 +2266,52 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
         </ul>
 
         <dl>
-          <dt id="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR (-16)</dt>
+          <dt id="PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR (-16)</dt>
           <dd>
 A request to generate a proof failed. See Section
 <a href="#add-proof"></a>, and Section <a href="#add-proof-set-chain"></a>.
           </dd>
-          <dt id="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR (-17)</dt>
+          <dt id="MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR (-17)</dt>
           <dd>
 A proof that is malformed was detected. See Section
 <a href="#verify-proof"></a>.
           </dd>
-          <dt id="#MISMATCHED_PROOF_PURPOSE_ERROR">MISMATCHED_PROOF_PURPOSE_ERROR (-18)</dt>
+          <dt id="MISMATCHED_PROOF_PURPOSE_ERROR">MISMATCHED_PROOF_PURPOSE_ERROR (-18)</dt>
           <dd>
 The `proofPurpose` value in a proof did not match the expected value. See
 Section <a href="#verify-proof"></a>.
           </dd>
-          <dt id="#INVALID_DOMAIN_ERROR">INVALID_DOMAIN_ERROR (-19)</dt>
+          <dt id="INVALID_DOMAIN_ERROR">INVALID_DOMAIN_ERROR (-19)</dt>
           <dd>
 The `domain` value in a proof did not match the expected value. See Section
 <a href="#verify-proof"></a>.
           </dd>
-          <dt id="#INVALID_CHALLENGE_ERROR">INVALID_CHALLENGE_ERROR (-20)</dt>
+          <dt id="INVALID_CHALLENGE_ERROR">INVALID_CHALLENGE_ERROR (-20)</dt>
           <dd>
 The `challenge` value in a proof did not match the expected value. See Section
 <a href="#verify-proof"></a>.
           </dd>
-          <dt id="#INVALID_VERIFICATION_METHOD_URL">INVALID_VERIFICATION_METHOD_URL (-21)</dt>
+          <dt id="INVALID_VERIFICATION_METHOD_URL">INVALID_VERIFICATION_METHOD_URL (-21)</dt>
           <dd>
 The `verificationMethod` value in a proof was malformed. See Section
 <a href="#retrieve-verification-method"></a>.
           </dd>
-          <dt id="#INVALID_CONTROLLER_DOCUMENT_ID">INVALID_CONTROLLER_DOCUMENT_ID (-22)</dt>
+          <dt id="INVALID_CONTROLLER_DOCUMENT_ID">INVALID_CONTROLLER_DOCUMENT_ID (-22)</dt>
           <dd>
 The `id` value in a <a>controller document</a> was malformed. See Section
 <a href="#retrieve-verification-method"></a>.
           </dd>
-          <dt id="#INVALID_CONTROLLER_DOCUMENT">INVALID_CONTROLLER_DOCUMENT (-23)</dt>
+          <dt id="INVALID_CONTROLLER_DOCUMENT">INVALID_CONTROLLER_DOCUMENT (-23)</dt>
           <dd>
 The <a>controller document</a> was malformed. See Section
 <a href="#retrieve-verification-method"></a>.
           </dd>
-          <dt id="#INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD (-24)</dt>
+          <dt id="INVALID_VERIFICATION_METHOD">INVALID_VERIFICATION_METHOD (-24)</dt>
           <dd>
 The <a>verification method</a> in a <a>controller document</a> was malformed. See Section
 <a href="#retrieve-verification-method"></a>.
           </dd>
-          <dt id="#INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD">INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD (-25)</dt>
+          <dt id="INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD">INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD (-25)</dt>
           <dd>
 The <a>verification method</a> in a <a>controller document</a> was not
 associated using the expected <a>verification relationship</a> as expressed

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -58,9 +58,13 @@ class:
     upper_value: sec:Proof
     defined_by: https://www.w3.org/TR/vc-di-eddsa/#ed25519signature2020
 
+  - id: Errors
+    label: Processing errors
+    defined_by: https://www.w3.org/TR/vc-di-eddsa/#errors
 
-# These are the class definitions in the CCG documents that are not defined in a VCWG document; they are all deprecated
-# In some cases a ccg document was found and used for the definition, but in some cases even that is missing...
+
+# These are the class definitions in the CCG documents that are not defined in a VCWG document; they are all deprecated.
+# In some cases, a CCG document was found and used for the definition, but in other cases, even that is missing...
 
 
   - id: EcdsaSecp256k1Signature2019
@@ -352,3 +356,44 @@ property:
       - label: Detached JSON Web Signature
         url: https://tools.ietf.org/html/rfc7797
 
+individual:
+  - id: PROOF_GENERATION_ERROR
+    upper_value: sec:Errors
+    label: Proof generation error
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#PROOF_GENERATION_ERROR
+  - id: MALFORMED_PROOF_ERROR
+    upper_value: sec:Errors
+    label: Malformed proof
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#MALFORMED_PROOF_ERROR
+  - id: MISMATCHED_PROOF_PURPOSE_ERROR
+    upper_value: sec:Errors
+    label: Mismatched proof purpose
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#MISMATCHED_PROOF_PURPOSE_ERROR
+  - id: INVALID_DOMAIN_ERROR
+    upper_value: sec:Errors
+    label: Invalid proof domain
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_DOMAIN_ERROR
+  - id: INVALID_CHALLENGE_ERROR
+    upper_value: sec:Errors
+    label: Invalid challenge
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CHALLENGE_ERROR
+  - id: INVALID_VERIFICATION_METHOD_URL
+    upper_value: sec:Errors
+    label: Invalid verification method URL
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD_URL
+  - id: INVALID_CONTROLLER_DOCUMENT_ID
+    upper_value: sec:Errors
+    label: Invalid controller document id
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CONTROLLER_DOCUMENT_ID
+  - id: INVALID_CONTROLLER_DOCUMENT
+    upper_value: sec:Errors
+    label: Invalid controller document
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CONTROLLER_DOCUMENT
+  - id: INVALID_VERIFICATION_METHOD
+    upper_value: sec:Errors
+    label: Invalid verification method
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD
+  - id: INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD
+    upper_value: sec:Errors
+    label: Invalid proof purpose for verification method
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -58,8 +58,8 @@ class:
     upper_value: sec:Proof
     defined_by: https://www.w3.org/TR/vc-di-eddsa/#ed25519signature2020
 
-  - id: Errors
-    label: Processing errors
+  - id: ProcessingError
+    label: Processing error
     defined_by: https://www.w3.org/TR/vc-di-eddsa/#errors
 
 
@@ -358,42 +358,42 @@ property:
 
 individual:
   - id: PROOF_GENERATION_ERROR
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Proof generation error
     defined_by: https://www.w3.org/TR/vc-data-integrity/#PROOF_GENERATION_ERROR
   - id: MALFORMED_PROOF_ERROR
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Malformed proof
     defined_by: https://www.w3.org/TR/vc-data-integrity/#MALFORMED_PROOF_ERROR
   - id: MISMATCHED_PROOF_PURPOSE_ERROR
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Mismatched proof purpose
     defined_by: https://www.w3.org/TR/vc-data-integrity/#MISMATCHED_PROOF_PURPOSE_ERROR
   - id: INVALID_DOMAIN_ERROR
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Invalid proof domain
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_DOMAIN_ERROR
   - id: INVALID_CHALLENGE_ERROR
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Invalid challenge
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CHALLENGE_ERROR
   - id: INVALID_VERIFICATION_METHOD_URL
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Invalid verification method URL
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD_URL
   - id: INVALID_CONTROLLER_DOCUMENT_ID
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Invalid controller document id
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CONTROLLER_DOCUMENT_ID
   - id: INVALID_CONTROLLER_DOCUMENT
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Invalid controller document
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CONTROLLER_DOCUMENT
   - id: INVALID_VERIFICATION_METHOD
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Invalid verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD
   - id: INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD
-    upper_value: sec:Errors
+    upper_value: sec:ProcessingError
     label: Invalid proof purpose for verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD


### PR DESCRIPTION
**This PR is not against the `main` branch but, rather, against the branch behind https://github.com/w3c/vc-data-integrity/pull/140**

The PR extends the official security vocabulary to include all the error terms, as RDF individuals, in the security vocabulary.

Note that I have **not** defined the terms described in that version ("code", "title", etc.) that are in the proposed specification. It would require to add them as bona fide properties with the `Errors` class as a domain, but I do not believe those (JSON) objects will ever appear as Linked Data. If I am wrong, then these terms should be added to the vocabulary as well (although in that case, it is a possible problem to see that the terms like 'title' or 'code' are extremely generic, hopefully it will not lead to clashes...)