### PR TITLE
Added final versions of some properties (with anchors)

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,7 +496,7 @@ The date and time the proof was created is OPTIONAL and, if included, MUST be
 specified as an [[XMLSCHEMA11-2]] combined date and time string.
           </dd>
 
-          <dt>expires</dt>
+          <dt><dfn class="lint-ignore">expires</dfn></dt>
           <dd>
 An OPTIONAL property that conveys the date and time that a proof expires and that, if present, MUST be
 specified as an [[XMLSCHEMA11-2]] combined date and time string.
@@ -539,7 +539,7 @@ that MUST verify before the current proof is processed. This property is used
 in Section <a href="#proof-chains"></a>.
           </dd>
 
-          <dt>nonce</dt>
+          <dt><dfn class="lint-ignore">nonce</dfn></dt>
           <dd>
 An OPTIONAL string value supplied by the proof creator. One use of this
 field is to increase privacy by decreasing linkability that is the result

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -190,6 +190,18 @@ property:
     domain: sec:Proof
     range: xsd:string
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-proofvalue
+    
+  - id: expires
+    label: Proof expiration time
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-expires
+    domain: sec:Proof
+    range: xsd:dateTime
+
+  - id: nonce
+    label: Nonce supplied by proof creator
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-nonce
+    domain: sec:Proof
+    range: xsd:string
 
   - id: authentication
     label: Authentication method
@@ -245,18 +257,6 @@ property:
         url: https://www.iana.org/assignments/jose/jose.xhtml
       - label: RFC 7517
         url: https://tools.ietf.org/html/rfc7517
-
-  - id: expires
-    label: Expiration time
-    range: xsd:dateTime
-    comment: The expiration time is typically associated with a <a href="#Key>`Key`</a> and specifies when the validity of the key will expire. <b><em>There is no URL yet in a VCWG document to <em>define</em> this term.</em></b>
-
-  - id: nonce
-    label: Nonce
-    # domain: sec:Signature
-    range: xsd:string
-    comment: |
-      This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a privileged request. <b><em>There is no URL yet in a VCWG document to <em>define</em> this term.</em></b>
 
   - id: revoked
     label: Revocation time


### PR DESCRIPTION
The following properties of the vocabulary are finalized:

- `expires` added by PR #124
- `nonce` added by #122


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/142.html" title="Last updated on Jul 31, 2023, 11:06 AM UTC (7ba7c39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/142/d5bb54d...7ba7c39.html" title="Last updated on Jul 31, 2023, 11:06 AM UTC (7ba7c39)">Diff</a>