### PR TITLE
Correcting previously mis-corrected sentence

### DIFF
--- a/index.html
+++ b/index.html
@@ -1837,9 +1837,9 @@ the <a>cryptographic suite</a> type; an identifier for the
 <a>verification method</a> (<var>verificationMethod</var>) that can be used to
 verify the authenticity of the proof; an [[!XMLSCHEMA11-2]] combined date
 and time string (<var>created</var>) containing the current date and time,
-accurate to at least one second, in Universal Time Code format, a
-<a href="#dfn-domain">security domain</a> (<var>domain</var>), and a
-receiver-supplied challenge (<var>challenge</var>) might also be specified in
+accurate to at least one second, in Universal Time Code format. A
+<a href="#dfn-domain">security domain</a> (<var>domain</var>) and/or a
+receiver-supplied challenge (<var>challenge</var>) MAY also be specified in
 the <var>options</var>. A <dfn>secured data document</dfn> is produced as
 output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
         </p>


### PR DESCRIPTION
**Important questions, where the answers may lead me to change this PR:**
* Are the `security domain` and/or `receiver-supplied challenge` both optional? 
* Can either be present without the other, or does including one mandate the other? 
* Are these the only optional `proof options` (i.e., while all the others are `MUST`, these are `MAY`)?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/vc-data-integrity/pull/143.html" title="Last updated on Aug 1, 2023, 4:12 PM UTC (161bee2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/143/28a168f...TallTed:161bee2.html" title="Last updated on Aug 1, 2023, 4:12 PM UTC (161bee2)">Diff</a>