### PR TITLE
Extended proof chain algorithms

### DIFF
--- a/index.html
+++ b/index.html
@@ -2073,9 +2073,9 @@ the <var>isProofVerified</var> value with this <var>proof</var>.
 For each <var>proof</var> in <var>proof_list</var> that contains a 
 <code>previousProof</code> attribute, modify the associated 
 <var>isProofVerified</var> by iteratively checking that the proof identified by
-the <code>id</code> value in <var>previousProof</var>, along with any 
-<code>previousProofs</code> up the chain, is valid. If <code>previousProof</code> is an
-array, then all previous proof proof chains identified by the array elements 
+the <code>id</code> value in <var>previousProof</var>, along with every 
+<code>previousProof</code> up the chain, is valid. If <code>previousProof</code> is an
+array, then all previous proofs identified by the array elements 
 MUST be valid for the current proof to be considered valid. Cycle detection, 
 such as keeping a list of previously visited proofs, MUST be used to guard 
 against malicious proofs. If a cycle is detected in a proof chain, 

--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@ value. The contents of this value are determined by a cryptosuite and set to the
           <dd>
 An OPTIONAL string value or unordered list of string values. Each value 
 identifies another <a>data integrity proof</a> that MUST verify before the 
-current proof is processed. In the case of an unordered list all referenced 
+current proof is processed. If an unordered list, all referenced 
 proofs in the array MUST verify. This property is used in Section 
 <a href="#proof-chains"></a>.
           </dd>
@@ -1950,8 +1950,8 @@ attribute is a string, check whether
 an element of the <var>proof_list</var> has a matching <code>id</code> attribute. 
 If not, a `PROOF_GENERATION_ERROR` MUST be raised. If the 
 <code>previousProof</code> attribute is an array, check that each element of that
-array is a string and that an element of the <var>proof_list</var> has a 
-matching <code>id</code> attribute. If not, a `PROOF_GENERATION_ERROR` MUST be 
+array is a string which matches the <code>id</code> attribute of an element
+of the <var>proof_list</var>. If not, a `PROOF_GENERATION_ERROR` MUST be 
 raised.
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -1935,7 +1935,7 @@ via the digital proof.
         <ol class="algorithm">
           <li>
 Let <var>proof</var> be set to <var>securedDocument</var>.<var>proof</var>. Let 
-<var>proof_list</var> be an empty list. If <var>proof</var> is a list copy all 
+<var>allProofs</var> be an empty list. If <var>proof</var> is a list copy all 
 the elements of <var>proof</var> to <var>proof_list</var>. If <var>proof</var> 
 is an object add a copy of that object to <var>proof_list</var>.
           </li>
@@ -2078,7 +2078,7 @@ the <code>id</code> value in <var>previousProof</var>, along with every
 array, then all previous proofs identified by the array elements 
 MUST be valid for the current proof to be considered valid. Cycle detection, 
 such as keeping a list of previously visited proofs, MUST be used to guard 
-against malicious proofs. If a cycle is detected in a proof chain, 
+against proof cycles. If a cycle is detected in a proof chain, 
 then a `PROOF_CHAIN_CYCLE_ERROR` MUST be raised.
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -1967,58 +1967,6 @@ Return <var>output</var> as the new <a>secured data document</a>.
           </li>
         </ol>
       </section>
-      
-      <section>
-        <h3>Add Proof Set/Chain</h3>
-        <p>
-          The following algorithm specifies how to incrementally add a proof to 
-          a proof set or proof chain starting with a secured document containing
-          either a proof or proof set/chain.
-          Required inputs are a <a>secured data document</a> 
-          (<var>securedDocument</var>) and <a>proof options</a> 
-          (<var>options</var>). The <a>proof options</a>
-          (<var>options</var>) must satisfy the criteria in 
-          section <a href="#add-proof"></a>.
-          A new <dfn>secured data document</dfn> is produced as
-          output. Whenever this algorithm encodes strings, it MUST use UTF-8 
-          encoding.
-        </p>
-
-        <ol class="algorithm">
-          <li>
-Let <var>proof</var> be set to <var>securedDocument</var>.<var>proof</var>. Let 
-<var>proof_list</var> be an empty list. If <var>proof</var> is a list copy all 
-the elements of <var>proof</var> to <var>proof_list</var>. If <var>proof</var> 
-is an object add a copy of that object to <var>proof_list</var>.
-          </li>
-          <li>
-Let the <var>unsecuredDocument</var> be a copy of the <var>securedDocument</var> 
-with the <var>proof</var> attribute removed. Let <var>output</var> be a copy of 
-the <var>unsecuredDocument</var>.
-          </li>
-          <li>
-If <var>options</var> contains a <code>previousProof</code> attribute and that 
-attribute is a string check if 
-an element of the <var>proof_list</var> has a matching <code>id</code> attribute. 
-If not  a `PROOF_GENERATION_ERROR` MUST be raised. If the 
-<code>previousProof</code> attribute is an array check that each element of that
-array is a string and that an element of the <var>proof_list</var> has a 
-matching <code>id</code> attribute. If not  a `PROOF_GENERATION_ERROR` MUST be 
-raised.
-          </li>
-          <li>
-Run steps 2 through 8 of the algorithm in section <a href="#add-proof"></a>. If 
-no exceptions are raised, append the generated <var>proof</var> value to the 
-<var>proof_list</var>; otherwise, raise the exception.
-          </li>
-          <li>
-Set <var>output</var>.<var>proof</var> to the value of <var>proof_list</var>.
-          </li>
-          <li>
-Return <var>output</var> as the new <a>secured data document</a>.
-          </li>
-        </ol>
-      </section>
 
       <section>
         <h3>Verify Proof</h3>

--- a/index.html
+++ b/index.html
@@ -2082,7 +2082,7 @@ against malicious proofs. If a cycle is detected in a proof chain,
 then a `PROOF_CHAIN_CYCLE_ERROR` MUST be raised.
           </li>
           <li>
-Return the <var>proof_list</var> along with each proofs associated 
+Return the <var>proof_list</var> along with each proof's associated 
 <var>isProofVerified</var> information.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -1692,71 +1692,52 @@ via the digital proof.
 
       </section>
       <section>
-        <h3>Add Proof Set</h3>
+        <h3>Add Proof Set/Chain</h3>
         <p>
-          The following algorithm specifies how to add a proof set to a 
-          document. Required inputs are an
-          <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
-          list (unordered) of
-          <a>proof options</a> (<var>options_list</var>). Each <a>proof options</a>
-          (<var>options</var>) in the list must satisfy the criteria in 
+          The following algorithm specifies how to incrementally add a proof to 
+          a proof set or proof chain starting with a secured document containing
+          either a proof or proof set/chain.
+          Required inputs are a <a>secured data document</a> 
+          (<var>securedDocument</var>) and <a>proof options</a> 
+          (<var>options</var>). The <a>proof options</a>
+          (<var>options</var>) must satisfy the criteria in 
           section <a href="#add-proof"></a>.
-          A <dfn>secured data document</dfn> is produced as
-          output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
+          A new <dfn>secured data document</dfn> is produced as
+          output. Whenever this algorithm encodes strings, it MUST use UTF-8 
+          encoding.
         </p>
 
         <ol class="algorithm">
           <li>
-Let <var>output</var> be a copy of <var>unsecuredDocument</var> and 
-<var>proof_list</var> be an empty list.
+Let <var>proof</var> be set to <var>securedDocument</var>.<var>proof</var>. Let 
+<var>proof_list</var> be an empty list. If <var>proof</var> is a list copy all 
+the elements of <var>proof</var> to <var>proof_list</var>. If <var>proof</var> 
+is an object add a copy of that object to <var>proof_list</var>.
           </li>
           <li>
-For each <var>options</var> in <var>options_list</var> run steps 2 through 8 of
-the algorithm in section <a href="#add-proof"></a>. If no exceptions are raised 
-append the generated <var>proof</var> value to the <var>proof_list</var> 
-otherwise raise the exception.
+Let the <var>unsecuredDocument</var> be a copy of the <var>securedDocument</var> 
+with the <var>proof</var> attribute removed. Let <var>output</var> be a copy of 
+the <var>unsecuredDocument</var>.
+          </li>
+          <li>
+If <var>options</var> contains a <code>previousProof</code> attribute check if 
+an element of the <var>proof_list</var> has a matching <code>id</code> attribute. 
+If not  a `PROOF_GENERATION_ERROR` MUST be raised.
+          </li>
+          <li>
+Run steps 2 through 8 of the algorithm in section <a href="#add-proof"></a>. If 
+no exceptions are raised append the generated <var>proof</var> value to the 
+<var>proof_list</var> otherwise raise the exception.
           </li>
           <li>
 Set <var>output</var>.<var>proof</var> to the value of <var>proof_list</var>.
           </li>
           <li>
-Return <var>output</var> as the <a>secured data document</a>.
+Return <var>output</var> as the new <a>secured data document</a>.
           </li>
         </ol>
       </section>
-      <section>
-        <h3>Add Proof Chain</h3>
-        <p>
-          The following algorithm specifies how to add a proof chain to a 
-          document. Required inputs are an
-          <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
-          (unordered) list of
-          <a>proof options</a> (<var>options_list</var>) to which an order will
-          be established. Each <a>proof options</a>
-          (<var>options</var>) in the list must satisfy the criteria in 
-          section <a href="#add-proof"></a>.
-          A <dfn>secured data document</dfn> is produced as
-          output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
-        </p>
-
-        <ol class="algorithm">
-          <li>
-For each <var>options</var> in <var>options_list</var> that represents a proof 
-that must come before another proof add an <code>id</code> attribute if it is 
-not already present.
-          </li>
-          <li>
-For each <var>options</var> in <var>options_list</var> that represents a proof 
-that must come after another proof add an <code>previousProof</code> attribute 
-with value the <code>id</code> of the proof that must come before it.
-not already present.
-          </li>
-          <li>
-Use this modified <var>options_list</var> in the algorithm of section 
-<a href="#add-proof-set"></a>.
-          </li>
-        </ol>        
-      </section>
+      
       <section>
         <h3>Verify Proof</h3>
 
@@ -1846,8 +1827,7 @@ In the case of a proof set or proof chain a <a>secured data document</a> has a
 The following algorithm specifies how to check the authenticity and
 integrity of a <a>secured data document</a> by verifying each
 proof in the <var>proof_list</var>. Required inputs are a
-<a>secured data document</a> (<var>securedDocument</var>) and
-<a>proof options</a> (<var>options</var>). A list of 
+<a>secured data document</a> (<var>securedDocument</var>). A list of 
 verification results is produced as output.
         </p>
         <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -522,10 +522,11 @@ value. The contents of this value are determined by a cryptosuite and set to the
 
           <dt>previousProof</dt>
           <dd>
-An optional string value or array of string values. Each value identifies 
-another <a>data integrity proof</a> that MUST verify before the current proof is 
-processed. In the case of an array all referenced proofs in the array MUST 
-verify. This property is used in Section <a href="#proof-chains"></a>.
+An optional string value or an unordered list of string values. Each value 
+identifies another <a>data integrity proof</a> that MUST verify before the 
+current proof is processed. In the case of an unordered list all referenced 
+proofs in the array MUST verify. This property is used in Section 
+<a href="#proof-chains"></a>.
           </dd>
 
         </dl>

--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@ value. The contents of this value are determined by a cryptosuite and set to the
 
           <dt><dfn class="lint-ignore">previousProof</dfn></dt>
           <dd>
-An optional string value or an unordered list of string values. Each value 
+An OPTIONAL string value or unordered list of string values. Each value 
 identifies another <a>data integrity proof</a> that MUST verify before the 
 current proof is processed. In the case of an unordered list all referenced 
 proofs in the array MUST verify. This property is used in Section 
@@ -1946,12 +1946,12 @@ the <var>unsecuredDocument</var>.
           </li>
           <li>
 If <var>options</var> contains a <code>previousProof</code> attribute and that 
-attribute is a string check if 
+attribute is a string, check whether 
 an element of the <var>proof_list</var> has a matching <code>id</code> attribute. 
-If not  a `PROOF_GENERATION_ERROR` MUST be raised. If the 
-<code>previousProof</code> attribute is an array check that each element of that
+If not, a `PROOF_GENERATION_ERROR` MUST be raised. If the 
+<code>previousProof</code> attribute is an array, check that each element of that
 array is a string and that an element of the <var>proof_list</var> has a 
-matching <code>id</code> attribute. If not  a `PROOF_GENERATION_ERROR` MUST be 
+matching <code>id</code> attribute. If not, a `PROOF_GENERATION_ERROR` MUST be 
 raised.
           </li>
           <li>
@@ -2051,7 +2051,7 @@ Return <var>isProofVerified</var> as the <a>verification result</a>.
       <section>
         <h3>Verify Proof Sets and Chains</h3>
         <p>
-In the case of a proof set or proof chain a <a>secured data document</a> has a 
+In a proof set or proof chain, a <a>secured data document</a> has a
 <code>proof</code> attribute which contains a list of proofs 
 (<var>proof_list</var>).
 The following algorithm specifies how to check the authenticity and
@@ -2065,21 +2065,21 @@ verification results is produced as output.
 Set <var>proof_list</var> to </var><var>securedDocument</var>.<var>proof</var>. 
           </li>
           <li>
-For each <var>proof</var> in <var>proof_list</var> run steps 2-11 of the algorithm in
-section <a href="verify-proof"></a> and if no exceptions are raised, associate
+For each <var>proof</var> in <var>proof_list</var>, run steps 2 through 11 of the algorithm in
+section <a href="verify-proof"></a>; if no exceptions are raised, associate
 the <var>isProofVerified</var> value with this <var>proof</var>.
           </li>
           <li>
 For each <var>proof</var> in <var>proof_list</var> that contains a 
-<code>previousProof</code> attribute modify the associated 
+<code>previousProof</code> attribute, modify the associated 
 <var>isProofVerified</var> by iteratively checking that the proof identified by
-the <code>id</code> value in <var>previousProof</var> is valid along with any 
-<code>previousProofs</code> up the chain. If <code>previousProof</code> is an
-array then all previous proof proof chains identified by the array elements 
-must be valid for the current proof to be considered valid. Cycle detection, 
+the <code>id</code> value in <var>previousProof</var>, along with any 
+<code>previousProofs</code> up the chain, is valid. If <code>previousProof</code> is an
+array, then all previous proof proof chains identified by the array elements 
+MUST be valid for the current proof to be considered valid. Cycle detection, 
 such as keeping a list of previously visited proofs, MUST be used to guard 
-against malicious proofs. If a cycle is detected in a proof chain 
-then a `PROOF_CHAIN_CYCLE_ERROR` must be raised.
+against malicious proofs. If a cycle is detected in a proof chain, 
+then a `PROOF_CHAIN_CYCLE_ERROR` MUST be raised.
           </li>
           <li>
 Return the <var>proof_list</var> along with each proofs associated 

--- a/index.html
+++ b/index.html
@@ -1697,7 +1697,7 @@ via the digital proof.
           The following algorithm specifies how to add a proof set to a 
           document. Required inputs are an
           <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
-          (unordered) list of
+          list (unordered) of
           <a>proof options</a> (<var>options_list</var>). Each <a>proof options</a>
           (<var>options</var>) in the list must satisfy the criteria in 
           section <a href="#add-proof"></a>.

--- a/index.html
+++ b/index.html
@@ -2196,21 +2196,21 @@ the <var>unsecuredDocument</var>.
           <li>
 If <var>options</var> contains a <code>previousProof</code> attribute and that
 attribute is a string, check whether
-an element of the <var>proofList</var> has a matching <code>id</code> attribute.
+an element of the <var>allProofs</var> has a matching <code>id</code> attribute.
 If not, an error MUST be raised and SHOULD convey an error type of
 <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>. If the
 <code>previousProof</code> attribute is an array, check that each element of that
 array is a string which matches the <code>id</code> attribute of an element
-of the <var>proofList</var>. If not, an error MUST be raised and SHOULD convey
+of the <var>allProofs</var>. If not, an error MUST be raised and SHOULD convey
 an error type of <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
           </li>
           <li>
 Run steps 2 through 8 of the algorithm in section <a href="#add-proof"></a>. If
 no exceptions are raised, append the generated <var>proof</var> value to the
-<var>proofList</var>; otherwise, raise the exception.
+<var>allProofs</var>; otherwise, raise the exception.
           </li>
           <li>
-Set <var>output</var>.<var>proof</var> to the value of <var>proofList</var>.
+Set <var>output</var>.<var>proof</var> to the value of <var>allProofs</var>.
           </li>
           <li>
 Return <var>output</var> as the new <a>secured data document</a>.
@@ -2320,24 +2320,24 @@ Return <var>isProofVerified</var> as the <a>verification result</a>.
         <p>
 In a proof set or proof chain, a <a>secured data document</a> has a
 <code>proof</code> attribute which contains a list of proofs
-(<var>proofList</var>).
+(<var>allProofs</var>).
 The following algorithm specifies how to check the authenticity and
 integrity of a <a>secured data document</a> by verifying each
-proof in the <var>proofList</var>. Required inputs are a
+proof in the <var>allProofs</var>. Required inputs are a
 <a>secured data document</a> (<var>securedDocument</var>). A list of
 verification results is produced as output.
         </p>
         <ol class="algorithm">
           <li>
-Set <var>proofList</var> to </var><var>securedDocument</var>.<var>proof</var>.
+Set <var>allProofs</var> to </var><var>securedDocument</var>.<var>proof</var>.
           </li>
           <li>
-For each <var>proof</var> in <var>proofList</var>, run steps 2 through 11 of the algorithm in
+For each <var>proof</var> in <var>allProofs</var>, run steps 2 through 11 of the algorithm in
 section <a href="verify-proof"></a>; if no exceptions are raised, associate
 the <var>isProofVerified</var> value with this <var>proof</var>.
           </li>
           <li>
-For each <var>proof</var> in <var>proofList</var> that contains a
+For each <var>proof</var> in <var>allProofs</var> that contains a
 <code>previousProof</code> attribute, modify the associated
 <var>isProofVerified</var> by iteratively checking that the proof identified by
 the <code>id</code> value in <var>previousProof</var>, along with every
@@ -2349,7 +2349,7 @@ against proof cycles. If a cycle is detected in a proof chain,
 then a `PROOF_CHAIN_CYCLE_ERROR` MUST be raised.
           </li>
           <li>
-Return the <var>proofList</var> along with each proof's associated
+Return the <var>allProofs</var> along with each proof's associated
 <var>isProofVerified</var> information.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -522,9 +522,10 @@ value. The contents of this value are determined by a cryptosuite and set to the
 
           <dt>previousProof</dt>
           <dd>
-An optional string value that identifies another <a>data integrity proof</a>
-that MUST verify before the current proof is processed. This property is used
-in Section <a href="#proof-chains"></a>.
+An optional string value or array of string values. Each value identifies 
+another <a>data integrity proof</a> that MUST verify before the current proof is 
+processed. In the case of an array all referenced proofs in the array MUST 
+verify. This property is used in Section <a href="#proof-chains"></a>.
           </dd>
 
         </dl>
@@ -1720,9 +1721,14 @@ with the <var>proof</var> attribute removed. Let <var>output</var> be a copy of
 the <var>unsecuredDocument</var>.
           </li>
           <li>
-If <var>options</var> contains a <code>previousProof</code> attribute check if 
+If <var>options</var> contains a <code>previousProof</code> attribute and that 
+attribute is a string check if 
 an element of the <var>proof_list</var> has a matching <code>id</code> attribute. 
-If not  a `PROOF_GENERATION_ERROR` MUST be raised.
+If not  a `PROOF_GENERATION_ERROR` MUST be raised. If the 
+<code>previousProof</code> attribute is an array check that each element of that
+array is a string and that an element of the <var>proof_list</var> has a 
+matching <code>id</code> attribute. If not  a `PROOF_GENERATION_ERROR` MUST be 
+raised.
           </li>
           <li>
 Run steps 2 through 8 of the algorithm in section <a href="#add-proof"></a>. If 
@@ -1844,7 +1850,12 @@ For each <var>proof</var> in <var>proof_list</var> that contains a
 <code>previousProof</code> attribute modify the associated 
 <var>isProofVerified</var> by iteratively checking that the proof identified by
 the <code>id</code> value in <var>previousProof</var> is valid along with any 
-<code>previousProofs</code> up the chain.
+<code>previousProofs</code> up the chain. If <code>previousProof</code> is an
+array then all previous proof proof chains identified by the array elements 
+must be valid for the current proof to be considered valid. Cycle detection, 
+such as keeping a list of previously visited proofs, MUST be used to guard 
+against malicious proofs. If a cycle is detected in a proof chain 
+then a `PROOF_CHAIN_CYCLE_ERROR` must be raised.
           </li>
           <li>
 Return the <var>proof_list</var> along with each proofs associated 

--- a/index.html
+++ b/index.html
@@ -1691,7 +1691,72 @@ via the digital proof.
         </p>
 
       </section>
+      <section>
+        <h3>Add Proof Set</h3>
+        <p>
+          The following algorithm specifies how to add a proof set to a 
+          document. Required inputs are an
+          <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
+          (unordered) list of
+          <a>proof options</a> (<var>options_list</var>). Each <a>proof options</a>
+          (<var>options</var>) in the list must satisfy the criteria in 
+          section <a href="#add-proof"></a>.
+          A <dfn>secured data document</dfn> is produced as
+          output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
+        </p>
 
+        <ol class="algorithm">
+          <li>
+Let <var>output</var> be a copy of <var>unsecuredDocument</var> and 
+<var>proof_list</var> be an empty list.
+          </li>
+          <li>
+For each <var>options</var> in <var>options_list</var> run steps 2 through 8 of
+the algorithm in section <a href="#add-proof"></a>. If no exceptions are raised 
+append the generated <var>proof</var> value to the <var>proof_list</var> 
+otherwise raise the exception.
+          </li>
+          <li>
+Set <var>output</var>.<var>proof</var> to the value of <var>proof_list</var>.
+          </li>
+          <li>
+Return <var>output</var> as the <a>secured data document</a>.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h3>Add Proof Chain</h3>
+        <p>
+          The following algorithm specifies how to add a proof chain to a 
+          document. Required inputs are an
+          <a>unsecured data document</a> (<var>unsecuredDocument</var>) and a
+          (unordered) list of
+          <a>proof options</a> (<var>options_list</var>) to which an order will
+          be established. Each <a>proof options</a>
+          (<var>options</var>) in the list must satisfy the criteria in 
+          section <a href="#add-proof"></a>.
+          A <dfn>secured data document</dfn> is produced as
+          output. Whenever this algorithm encodes strings, it MUST use UTF-8 encoding.
+        </p>
+
+        <ol class="algorithm">
+          <li>
+For each <var>options</var> in <var>options_list</var> that represents a proof 
+that must come before another proof add an <code>id</code> attribute if it is 
+not already present.
+          </li>
+          <li>
+For each <var>options</var> in <var>options_list</var> that represents a proof 
+that must come after another proof add an <code>previousProof</code> attribute 
+with value the <code>id</code> of the proof that must come before it.
+not already present.
+          </li>
+          <li>
+Use this modified <var>options_list</var> in the algorithm of section 
+<a href="#add-proof-set"></a>.
+          </li>
+        </ol>        
+      </section>
       <section>
         <h3>Verify Proof</h3>
 
@@ -1771,6 +1836,41 @@ Return <var>isProofVerified</var> as the <a>verification result</a>.
           </li>
         </ol>
 
+      </section>
+      <section>
+        <h3>Verify Proof Sets and Chains</h3>
+        <p>
+In the case of a proof set or proof chain a <a>secured data document</a> has a 
+<code>proof</code> attribute which contains a list of proofs 
+(<var>proof_list</var>).
+The following algorithm specifies how to check the authenticity and
+integrity of a <a>secured data document</a> by verifying each
+proof in the <var>proof_list</var>. Required inputs are a
+<a>secured data document</a> (<var>securedDocument</var>) and
+<a>proof options</a> (<var>options</var>). A list of 
+verification results is produced as output.
+        </p>
+        <ol class="algorithm">
+          <li>
+Set <var>proof_list</var> to </var><var>securedDocument</var>.<var>proof</var>. 
+          </li>
+          <li>
+For each <var>proof</var> in <var>proof_list</var> run steps 2-11 of the algorithm in
+section <a href="verify-proof"></a> and if no exceptions are raised, associate
+the <var>isProofVerified</var> value with this <var>proof</var>.
+          </li>
+          <li>
+For each <var>proof</var> in <var>proof_list</var> that contains a 
+<code>previousProof</code> attribute modify the associated 
+<var>isProofVerified</var> by iteratively checking that the proof identified by
+the <code>id</code> value in <var>previousProof</var> is valid along with any 
+<code>previousProofs</code> up the chain.
+          </li>
+          <li>
+Return the <var>proof_list</var> along with each proofs associated 
+<var>isProofVerified</var> information.
+          </li>
+        </ol>
       </section>
 
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -1935,7 +1935,7 @@ via the digital proof.
         <ol class="algorithm">
           <li>
 Let <var>proof</var> be set to <var>securedDocument</var>.<var>proof</var>. Let 
-<var>allProofs</var> be an empty list. If <var>proof</var> is a list copy all 
+<var>allProofs</var> be an empty list. If <var>proof</var> is a list, copy all 
 the elements of <var>proof</var> to <var>allProofs</var>. If <var>proof</var> 
 is an object add a copy of that object to <var>allProofs</var>.
           </li>

--- a/index.html
+++ b/index.html
@@ -1726,8 +1726,8 @@ If not  a `PROOF_GENERATION_ERROR` MUST be raised.
           </li>
           <li>
 Run steps 2 through 8 of the algorithm in section <a href="#add-proof"></a>. If 
-no exceptions are raised append the generated <var>proof</var> value to the 
-<var>proof_list</var> otherwise raise the exception.
+no exceptions are raised, append the generated <var>proof</var> value to the 
+<var>proof_list</var>; otherwise, raise the exception.
           </li>
           <li>
 Set <var>output</var>.<var>proof</var> to the value of <var>proof_list</var>.

--- a/index.html
+++ b/index.html
@@ -1936,8 +1936,8 @@ via the digital proof.
           <li>
 Let <var>proof</var> be set to <var>securedDocument</var>.<var>proof</var>. Let 
 <var>allProofs</var> be an empty list. If <var>proof</var> is a list copy all 
-the elements of <var>proof</var> to <var>proof_list</var>. If <var>proof</var> 
-is an object add a copy of that object to <var>proof_list</var>.
+the elements of <var>proof</var> to <var>allProofs</var>. If <var>proof</var> 
+is an object add a copy of that object to <var>allProofs</var>.
           </li>
           <li>
 Let the <var>unsecuredDocument</var> be a copy of the <var>securedDocument</var> 


### PR DESCRIPTION
This PR addresses issues https://github.com/w3c/vc-data-integrity/issues/87 and https://github.com/w3c/vc-data-integrity/issues/120.  The proof chain *addition* and *verification* algorithms are extended to allow the case where `previousProof` is an unordered  list, i.e., the validity of a proof (signature) may dependent on two or more independent signatures.

In addition the verification algorithm warns implementers on the dangers of **cycles** that could occur in a malicious proof chain and suggests on simple method of detection via tracking visited proofs. Note that cycle detection is a fairly well established area in computer science and graph theory so kept this discussion fairly short.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/145.html" title="Last updated on Aug 14, 2023, 4:57 PM UTC (0d2a850)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/145/3b3e64a...Wind4Greg:0d2a850.html" title="Last updated on Aug 14, 2023, 4:57 PM UTC (0d2a850)">Diff</a>