### PR TITLE
Define anchors for secretKeyJwk and secretKeyMultibase

### DIFF
--- a/index.html
+++ b/index.html
@@ -933,7 +933,7 @@ using the `<a>controller</a>` property at the highest level of the
 Verification material is any information that is used by a process that applies
 a <a>verification method</a>. The `type` of a <a>verification method</a> is
 expected to be used to determine its compatibility with such processes. Examples
-of verification material include `JsonWebKey` and `Multikey`.
+of verification methods include `JsonWebKey` and `Multikey`.
 A <a>cryptographic suite</a> specification is responsible for specifying the
 <a>verification method</a> `type` and its associated verification material
 format. For examples, see
@@ -1011,7 +1011,7 @@ When specifing a `Multikey`, the object takes the following form:
             <dl>
               <dt>type</dt>
               <dd>
-The `type` property MUST contain the string `Multikey`.
+The value of the `type` property MUST contain the string `Multikey`.
               </dd>
               <dt><dfn class="lint-ignore">publicKeyMultibase</dfn></dt>
               <dd>
@@ -1089,7 +1089,7 @@ When specifing a `JsonWebKey`, the object takes the following form:
             <dl>
               <dt>type</dt>
               <dd>
-The `type` property MUST contain the string `JsonWebKey`.
+The value of the `type` property MUST contain the string `JsonWebKey`.
               </dd>
               <dt><dfn class="lint-ignore">publicKeyJwk</dfn></dt>
               <dd>

--- a/index.html
+++ b/index.html
@@ -1021,7 +1021,11 @@ The `type` property MUST contain the string `Multikey`.
 The `publicKeyMultibase` property is OPTIONAL. If present, the value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
               </dd>
-
+              <dt><dfn>secretKeyMultibase</dfn></dt>
+              <dd>
+The `secretKeyMultibase` property is OPTIONAL. If present, the value MUST be a
+[[MULTIBASE]] encoded [[MULTICODEC]] value.
+              </dd>
             </dl>
 
             <p>

--- a/index.html
+++ b/index.html
@@ -1016,12 +1016,12 @@ When specifing a `Multikey`, the object takes the following form:
               <dd>
 The `type` property MUST contain the string `Multikey`.
               </dd>
-              <dt><dfn>publicKeyMultibase</dfn></dt>
+              <dt><dfn class="lint-ignore">publicKeyMultibase</dfn></dt>
               <dd>
 The `publicKeyMultibase` property is OPTIONAL. If present, the value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
               </dd>
-              <dt><dfn>secretKeyMultibase</dfn></dt>
+              <dt><dfn class="lint-ignore">secretKeyMultibase</dfn></dt>
               <dd>
 The `secretKeyMultibase` property is OPTIONAL. If present, the value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
@@ -1094,7 +1094,7 @@ When specifing a `JsonWebKey`, the object takes the following form:
               <dd>
 The `type` property MUST contain the string `JsonWebKey`.
               </dd>
-              <dt id="publickeyjwk">publicKeyJwk</dt>
+              <dt><dfn class="lint-ignore">publicKeyJwk</dfn></dt>
               <dd>
 The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
 be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
@@ -1108,7 +1108,7 @@ the public key fingerprint [[RFC7638]]. See the first key in
 <a href="#example-various-verification-method-types"></a> for an example of a
 public key with a compound key identifier.
               </dd>
-              <dt id="secretkeyjwk">secretKeyJwk</dt>
+              <dt><dfn class="lint-ignore">secretKeyJwk</dfn></dt>
               <dd>
 The `secretKeyJwk` property is OPTIONAL. If present, the value MUST be a <a
 data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that conforms

--- a/index.html
+++ b/index.html
@@ -931,28 +931,25 @@ using the `<a>controller</a>` property at the highest level of the
 
             <p>
 Verification material is any information that is used by a process that applies
-a <a>verification method</a>. The `type` of a <a>verification
-method</a> is expected to be used to determine its compatibility with such
-processes. Examples of verification material properties are
-`publicKeyJwk` or `publicKeyMultibase`. A
-<a>cryptographic suite</a> specification is responsible for specifying the
-<a>verification method</a> `type` and its associated verification
-material. For example, see <a href="https://w3c-ccg.github.io/lds-jws2020/">JSON
-Web Signature 2020</a> and <a
-href="https://w3c-ccg.github.io/lds-ed25519-2020/">Ed25519 Signature 2020</a>.
-For all registered <a>verification method</a> types and associated verification
-material available for <a>controllers</a>, please see the Data Integrity
-Specification Registries [TBD - DIS-REGISTRIES].
+a <a>verification method</a>. The `type` of a <a>verification method</a> is
+expected to be used to determine its compatibility with such processes. Examples
+of verification material include `JsonWebKey` and `Multikey`.
+A <a>cryptographic suite</a> specification is responsible for specifying the
+<a>verification method</a> `type` and its associated verification material
+format. For examples, see
+<a href="https://www.w3.org/TR/vc-di-ecdsa/">the Data Integrity ECDSA
+Cryptosuites</a> and <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">
+the Data Integrity EdDSA Cryptosuites</a>. For a list of <a>verification
+method</a> types please see the [[?SECURITY-VOCABULARY]].
             </p>
 
             <p>
 To increase the likelihood of interoperable implementations, this specification
-limits the number of formats for expressing verification material in a <a>controller
-document</a>. The fewer formats that implementers have to
+limits the number of formats for expressing verification material in a
+<a>controller document</a>. The fewer formats that implementers have to
 implement, the more likely it will be that they will support all of them. This
 approach attempts to strike a delicate balance between ease of implementation
 and supporting formats that have historically had broad deployment.
-Two supported verification material properties are listed below:
             </p>
 
             <p>
@@ -963,8 +960,8 @@ properties for the same material. For example, expressing key material in a
             </p>
 
             <p>
-An example of a <a>controller document</a> containing <a>verification methods</a> using
-both properties above is shown below.
+An example of a <a>controller document</a> containing <a>verification
+methods</a> using both properties above is shown below.
             </p>
 
             <pre id="example-various-verification-method-types"

--- a/index.html
+++ b/index.html
@@ -940,7 +940,7 @@ format. For examples, see
 <a href="https://www.w3.org/TR/vc-di-ecdsa/">the Data Integrity ECDSA
 Cryptosuites</a> and <a href="https://w3c-ccg.github.io/lds-ed25519-2020/">
 the Data Integrity EdDSA Cryptosuites</a>. For a list of <a>verification
-method</a> types please see the [[?SECURITY-VOCABULARY]].
+method</a> types, please see the [[?SECURITY-VOCABULARY]].
             </p>
 
             <p>
@@ -948,8 +948,8 @@ To increase the likelihood of interoperable implementations, this specification
 limits the number of formats for expressing verification material in a
 <a>controller document</a>. The fewer formats that implementers have to
 implement, the more likely it will be that they will support all of them. This
-approach attempts to strike a delicate balance between ease of implementation
-and supporting formats that have historically had broad deployment.
+approach attempts to strike a delicate balance between easing implementation
+and providing support for formats that have historically had broad deployment.
             </p>
 
             <p>
@@ -1015,12 +1015,12 @@ The value of the `type` property MUST contain the string `Multikey`.
               </dd>
               <dt><dfn class="lint-ignore">publicKeyMultibase</dfn></dt>
               <dd>
-The `publicKeyMultibase` property is OPTIONAL. If present, the value MUST be a
+The `publicKeyMultibase` property is OPTIONAL. If present, its value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
               </dd>
               <dt><dfn class="lint-ignore">secretKeyMultibase</dfn></dt>
               <dd>
-The `secretKeyMultibase` property is OPTIONAL. If present, the value MUST be a
+The `secretKeyMultibase` property is OPTIONAL. If present, its value MUST be a
 [[MULTIBASE]] encoded [[MULTICODEC]] value.
               </dd>
             </dl>
@@ -1093,10 +1093,10 @@ The value of the `type` property MUST contain the string `JsonWebKey`.
               </dd>
               <dt><dfn class="lint-ignore">publicKeyJwk</dfn></dt>
               <dd>
-The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
+The `publicKeyJwk` property is OPTIONAL. If present, its value MUST
 be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
 conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
-include any members of the private information class, such as "d", as described
+include any members of the private information class, such as `d`, as described
 in the <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">JWK
 Registration Template</a>. It is RECOMMENDED that verification methods that use
 JWKs [[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as
@@ -1107,7 +1107,7 @@ public key with a compound key identifier.
               </dd>
               <dt><dfn class="lint-ignore">secretKeyJwk</dfn></dt>
               <dd>
-The `secretKeyJwk` property is OPTIONAL. If present, the value MUST be a <a
+The `secretKeyJwk` property is OPTIONAL. If present, its value MUST be a <a
 data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that conforms
 to [[RFC7517]].
               </dd>

--- a/index.html
+++ b/index.html
@@ -934,7 +934,7 @@ Verification material is any information that is used by a process that applies
 a <a>verification method</a>. The `type` of a <a>verification
 method</a> is expected to be used to determine its compatibility with such
 processes. Examples of verification material properties are
-`<a>publicKeyJwk</a>` or `<a>publicKeyMultibase</a>`. A
+`publicKeyJwk` or `publicKeyMultibase`. A
 <a>cryptographic suite</a> specification is responsible for specifying the
 <a>verification method</a> `type` and its associated verification
 material. For example, see <a href="https://w3c-ccg.github.io/lds-jws2020/">JSON
@@ -954,25 +954,6 @@ approach attempts to strike a delicate balance between ease of implementation
 and supporting formats that have historically had broad deployment.
 Two supported verification material properties are listed below:
             </p>
-
-            <dl>
-              <dt><dfn>publicKeyMultibase</dfn></dt>
-              <dd>
-                <p>
-The `publicKeyMultibase` property is OPTIONAL. This feature is
-non-normative. If present, the value MUST be a <a
-data-cite="INFRA#string">string</a> representation of a [[MULTIBASE]] encoded
-public key.
-                </p>
-                <p class="advisement">
-Note that the [[?MULTIBASE]] specification is not yet a standard and is
-subject to change. There might be some use cases for this data format
-where `<b>public</b>KeyMultibase` is defined, to allow for
-expression of <a>public keys</a>, but `<b>private</b>KeyMultibase`
-is not defined, to protect against accidental leakage of secret keys.
-                </p>
-              </dd>
-          </dl>
 
             <p>
 A <a>verification method</a> MUST NOT contain multiple verification material
@@ -1024,9 +1005,27 @@ both properties above is shown below.
 The Multikey data model is a specific type of <a>verification method</a> that
 utilizes the [[MULTICODEC]] specification to encode key types into a single
 binary stream that is then encoded using the [[MULTIBASE]] specification.
-To encode a Multikey, the <a>verification method</a> `type` MUST be set to
-`Multikey` and the `publicKeyMultibase` value MUST be a [[MULTIBASE]] encoded
-[[MULTICODEC]] value. An example of a Multikey is provided below:
+            </p>
+
+            <p>
+When specifing a `Multikey`, the object takes the following form:
+            </p>
+
+            <dl>
+              <dt>type</dt>
+              <dd>
+The `type` property MUST contain the string `Multikey`.
+              </dd>
+              <dt><dfn>publicKeyMultibase</dfn></dt>
+              <dd>
+The `publicKeyMultibase` property is OPTIONAL. If present, the value MUST be a
+[[MULTIBASE]] encoded [[MULTICODEC]] value.
+              </dd>
+
+            </dl>
+
+            <p>
+An example of a Multikey is provided below:
             </p>
 
             <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -956,22 +956,6 @@ Two supported verification material properties are listed below:
             </p>
 
             <dl>
-              <dt><dfn>publicKeyJwk</dfn></dt>
-              <dd>
-                <p>
-The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
-be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
-conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
-contain "d", or any other members of the private information class as described
-in <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">Registration
-Template</a>. It is RECOMMENDED that verification methods that use JWKs
-[[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as
-their fragment identifier. It is RECOMMENDED that JWK
-`kid` values are set to the public key fingerprint [[RFC7638]]. See
-the first key in <a href="#example-various-verification-method-types"></a> for
-an example of a public key with a compound key identifier.
-                </p>
-              </dd>
               <dt><dfn>publicKeyMultibase</dfn></dt>
               <dd>
                 <p>
@@ -1095,10 +1079,37 @@ is a 32-byte raw Ed25519 private key.
             <p>
 The JSON Web Key (JWK) data model is a specific type of <a>verification method</a>
 that uses the JWK specification [[RFC7517]] to encode key types into a
-set of parameters. To encode a JSON Web Key, the <a>verification method</a>
-`type` MUST be set to `JsonWebKey` and the `publicKeyJwk` or `secretKeyJwk`
-value MUST be a valid JWK value as described in [[RFC7517]]. An example of a
-JSON Web Key is provided below:
+set of parameters.
+            </p>
+
+            <p>
+When specifing a `JsonWebKey`, the object takes the following form:
+            </p>
+
+            <dl>
+              <dt>type</dt>
+              <dd>
+The `type` property MUST contain the string `JsonWebKey`.
+              </dd>
+              <dt id="publickeyjwk">publicKeyJwk</dt>
+              <dd>
+The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
+be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
+conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
+any members of the private information class, such as "d", as described
+in the <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">JWK
+Registration Template</a>. It is RECOMMENDED that verification methods that use
+JWKs [[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as
+their fragment identifier. It is RECOMMENDED that JWK `kid` values are set to
+the public key fingerprint [[RFC7638]]. See the first key in
+<a href="#example-various-verification-method-types"></a> for an example of a
+public key with a compound key identifier.
+              </dd>
+
+            </dl>
+
+            <p>
+An example of an object that conforms to this data model is provided below:
             </p>
 
             <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -1096,7 +1096,7 @@ The `type` property MUST contain the string `JsonWebKey`.
 The `publicKeyJwk` property is OPTIONAL. If present, the value MUST
 be a <a data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that
 conforms to [[RFC7517]]. The <a data-cite="INFRA#ordered-map">map</a> MUST NOT
-any members of the private information class, such as "d", as described
+include any members of the private information class, such as "d", as described
 in the <a href="https://tools.ietf.org/html/rfc7517#section-8.1.1">JWK
 Registration Template</a>. It is RECOMMENDED that verification methods that use
 JWKs [[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as

--- a/index.html
+++ b/index.html
@@ -1105,7 +1105,12 @@ the public key fingerprint [[RFC7638]]. See the first key in
 <a href="#example-various-verification-method-types"></a> for an example of a
 public key with a compound key identifier.
               </dd>
-
+              <dt id="secretkeyjwk">secretKeyJwk</dt>
+              <dd>
+The `secretKeyJwk` property is OPTIONAL. If present, the value MUST be a <a
+data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that conforms
+to [[RFC7517]].
+              </dd>
             </dl>
 
             <p>


### PR DESCRIPTION
This PR addresses issue #151 by refactoring the verification material sections and adding anchors for secretKeyJwk and secretKeyMultibase.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/152.html" title="Last updated on Aug 10, 2023, 12:55 AM UTC (f5f82e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/152/52cdeef...f5f82e2.html" title="Last updated on Aug 10, 2023, 12:55 AM UTC (f5f82e2)">Diff</a>