### PR TITLE
Add anchor and definition for proof property.

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,7 +448,10 @@ information is provided using Linked Data vocabularies such as the
         </p>
 
         <p>
-The following attributes are defined for use in a <a>data integrity proof</a>:
+When expressing a <a>data integrity proof</a> on an object, a
+<dfn class="lint-ignore">`proof`</dfn> property MUST be used where its value is a
+single object, or an unordered set of objects, expressed using the properties
+below:
         </p>
 
         <dl style="margin-left: 1em;">


### PR DESCRIPTION
This addresses issue #129 by adding an anchor for the `proof` property that the vocabulary document can use, as well as providing a normative statement around the value of the property.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/153.html" title="Last updated on Aug 6, 2023, 5:36 PM UTC (105bdba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/153/73bf77e...105bdba.html" title="Last updated on Aug 6, 2023, 5:36 PM UTC (105bdba)">Diff</a>