### PR TITLE
Add revoked definition and anchor for vocabulary.

### DIFF
--- a/index.html
+++ b/index.html
@@ -921,7 +921,7 @@ data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
                 <dd>
 The `revoked` property is OPTIONAL. If provided, it MUST be an [[XMLSCHEMA11-2]]
 combined date and time string specifying when the <a>verification method</a>
-ceased to be used. Once the value is set, it is not expected to be updated, and
+SHOULD cease to be used. Once the value is set, it is not expected to be updated, and
 systems depending on the value are expected to not verify any proofs associated
 with the <a>verification method</a> at or after the time of revocation.
                 </dd>

--- a/index.html
+++ b/index.html
@@ -917,6 +917,14 @@ Registries [TBD -- DIS-REGISTRIES].
 The value of the `controller` property MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
                 </dd>
+                <dt><dfn class="lint-ignore">revoked</dfn></dt>
+                <dd>
+The `revoked` property is OPTIONAL. If provided, it MUST be an [[XMLSCHEMA11-2]]
+combined date and time string specifying when the <a>verification method</a>
+ceased to be used. Once the value is set, it is not expected to be updated, and
+systems depending on the value are expected to not verify any proofs associated
+with the <a>verification method</a> at or after the time of revocation.
+                </dd>
               </dl>
             </dd>
           </dl>


### PR DESCRIPTION
This PR partially addresses issue #129 by adding a definition and anchor for the `revoked` property.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/154.html" title="Last updated on Aug 12, 2023, 7:53 PM UTC (fca95c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/154/d148c86...fca95c0.html" title="Last updated on Aug 12, 2023, 7:53 PM UTC (fca95c0)">Diff</a>