### PR TITLE
Add text on difference between proof and VC validity periods.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1543,10 +1543,10 @@ href="#dfn-expires">`expires`</a> properties, and the validity period of a
 <a data-cite="?VC-DATA-MODEL-2.0#defn-validUntil">`validUntil`</a> properties.
 While these properties might sometimes express the same validity periods, at
 other times they might not be aligned. When verifying a
-<a href="#proofs">proof</a>, it is important to ensure that the time is within
-the validity period for the proof. When
-<a data-cite="?VC-DATA-MODEL-2.0#validation">validating</a>
-a <a>verifiable credential</a>, it is important to ensure that the time is
+<a href="#proofs">proof</a>, it is important to ensure that the time of interest
+(the current time or another time) is within the validity period for the proof.
+When <a data-cite="?VC-DATA-MODEL-2.0#validation">validating</a> a
+<a>verifiable credential</a>, it is important to ensure that the time of interest is
 within the validity period for the <a>verifiable credential</a>. Note that a
 failure to validate either the validity period for the <a
 href="#proofs">proof</a>, or the validity period for the <a>verifiable

--- a/index.html
+++ b/index.html
@@ -1500,6 +1500,7 @@ this specification.
 
       <section>
         <h2>Relationship to Verifiable Credentials</h2>
+
         <p>
 Cryptographic suites that implement this specification can be used to secure
 <a data-cite="?VC-DATA-MODEL-2.0#dfn-verifiable-credential">
@@ -1507,8 +1508,11 @@ verifiable credentials</a> and
 <a data-cite="?VC-DATA-MODEL-2.0#dfn-verifiable-presentation">
 verifiable presentations</a>. Implementers
 that are addressing those use cases are cautioned that additional checks might
-be appropriate when processing those types of documents. For example, there are
-some use cases where it is important to ensure that the
+be appropriate when processing those types of documents.
+        </p>
+
+        <p>
+There are some use cases where it is important to ensure that the
 <a>verification method</a> used in a proof is associated with the
 <a data-cite="?VC-DATA-MODEL-2.0#issuer">`issuer`</a> in a
 <a data-cite="?VC-DATA-MODEL-2.0#dfn-verifiable-credential">
@@ -1527,6 +1531,26 @@ This particular association indicates that the
 <a data-cite="?VC-DATA-MODEL-2.0#dfn-holder">`holder`</a>, respectively,
 is the controller of the <a>verification method</a> used to verify
 the proof.
+        </p>
+
+        <p>
+Document authors and implementers are advised to understand the difference
+between the validity period of a <a href="#proofs">proof</a>, which is expressed
+using the <a href="#dfn-created">`created`</a> and <a
+href="#dfn-expires">`expires`</a> properties, and the validity period of a
+<a>verifiable credential</a>, which is expressed using the
+<a data-cite="?VC-DATA-MODEL-2.0#defn-validFrom">`validFrom`</a> and
+<a data-cite="?VC-DATA-MODEL-2.0#defn-validUntil">`validUntil`</a> properties.
+While these properties might sometimes express the same validity periods, at
+other times they might not be aligned. When verifying a
+<a href="#proofs">proof</a>, it is important to ensure that the time is within
+the validity period for the proof. When
+<a data-cite="?VC-DATA-MODEL-2.0#validation">validating</a>
+a <a>verifiable credential</a>, it is important to ensure that the time is
+within the validity period for the <a>verifiable credential</a>. Note that a
+failure to validate either the validity period for the <a
+href="#proofs">proof</a>, or the validity period for the <a>verifiable
+credential</a> might result in accepting data that ought to have been rejected.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1550,7 +1550,7 @@ When <a data-cite="?VC-DATA-MODEL-2.0#validation">validating</a> a
 within the validity period for the <a>verifiable credential</a>. Note that a
 failure to validate either the validity period for the <a
 href="#proofs">proof</a>, or the validity period for the <a>verifiable
-credential</a> might result in accepting data that ought to have been rejected.
+credential</a>, might result in accepting data that ought to have been rejected.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1538,19 +1538,27 @@ Document authors and implementers are advised to understand the difference
 between the validity period of a <a href="#proofs">proof</a>, which is expressed
 using the <a href="#dfn-created">`created`</a> and <a
 href="#dfn-expires">`expires`</a> properties, and the validity period of a
-<a>verifiable credential</a>, which is expressed using the
+<a data-cite="?VC-DATA-MODEL-2.0#dfn-credential">credential</a>,
+which is expressed using the
 <a data-cite="?VC-DATA-MODEL-2.0#defn-validFrom">`validFrom`</a> and
 <a data-cite="?VC-DATA-MODEL-2.0#defn-validUntil">`validUntil`</a> properties.
 While these properties might sometimes express the same validity periods, at
 other times they might not be aligned. When verifying a
 <a href="#proofs">proof</a>, it is important to ensure that the time of interest
-(the current time or another time) is within the validity period for the proof.
+(which might be the current time or any other time) is within the
+validity period for the proof (that is, between
+<a href="#dfn-created">`created`</a> and <a href="#dfn-expires">`expires`</a> ).
 When <a data-cite="?VC-DATA-MODEL-2.0#validation">validating</a> a
-<a>verifiable credential</a>, it is important to ensure that the time of interest is
-within the validity period for the <a>verifiable credential</a>. Note that a
+<a>verifiable credential</a>, it is important to ensure that the time of
+interest is within the validity period for the
+<a data-cite="?VC-DATA-MODEL-2.0#dfn-credential">credential</a> (that is,
+betweeen
+<a data-cite="?VC-DATA-MODEL-2.0#defn-validFrom">`validFrom`</a> and
+<a data-cite="?VC-DATA-MODEL-2.0#defn-validUntil">`validUntil`</a>). Note that a
 failure to validate either the validity period for the <a
-href="#proofs">proof</a>, or the validity period for the <a>verifiable
-credential</a>, might result in accepting data that ought to have been rejected.
+href="#proofs">proof</a>, or the validity period for the
+<a data-cite="?VC-DATA-MODEL-2.0#dfn-credential">credential</a>, might result
+in accepting data that ought to have been rejected.
         </p>
       </section>
 


### PR DESCRIPTION
This PR attempts to address issue #78 by adding text to the "Relationship to VCs" section on the difference between proof and VC validity periods.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/155.html" title="Last updated on Aug 17, 2023, 6:09 PM UTC (0c4701f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/155/73bf77e...0c4701f.html" title="Last updated on Aug 17, 2023, 6:09 PM UTC (0c4701f)">Diff</a>