### PR TITLE
Update domain to support arrays of domain values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -504,12 +504,15 @@ specified as an [[XMLSCHEMA11-2]] combined date and time string.
 
           <dt id="defn-domain">domain</dt>
           <dd>
-The creator of a proof SHOULD include a string value that indicates its intended usage, which a verifier SHOULD use to ensure the proof was intended to be used by them. The
-specification of the `domain` parameter is useful in challenge-response
-protocols where the verifier is operating from within a security domain known to
-the creator of the proof. Examples of a domain parameter include:
-`domain.example` (DNS domain), `https://domain.example:8443` (full Web origin),
-`mycorp-intranet` (well-known text string), and
+An OPTIONAL property that conveys one or more security domains in which the
+proof is meant to be used. If specified, the associated value MUST be either a
+string, or an unordered set of strings. A verifier SHOULD use the value to
+ensure that the proof was intended to be used in the security domain in which
+the verifier is operating. The specification of the `domain` parameter is useful
+in challenge-response protocols where the verifier is operating from within a
+security domain known to the creator of the proof. Examples domain values
+include: `domain.example` (DNS domain), `https://domain.example:8443`
+(Web origin), `mycorp-intranet` (bespoke text string), and
 `b31d37d4-dd59-47d3-9dd8-c973da43b63a` (UUID).
           </dd>
 

--- a/index.html
+++ b/index.html
@@ -504,13 +504,13 @@ specified as an [[XMLSCHEMA11-2]] combined date and time string.
 
           <dt id="defn-domain">domain</dt>
           <dd>
-An OPTIONAL property that conveys one or more security domains in which the
+The `domain` property is OPTIONAL. It conveys one or more security domains in which the
 proof is meant to be used. If specified, the associated value MUST be either a
 string, or an unordered set of strings. A verifier SHOULD use the value to
 ensure that the proof was intended to be used in the security domain in which
 the verifier is operating. The specification of the `domain` parameter is useful
 in challenge-response protocols where the verifier is operating from within a
-security domain known to the creator of the proof. Examples domain values
+security domain known to the creator of the proof. Example domain values
 include: `domain.example` (DNS domain), `https://domain.example:8443`
 (Web origin), `mycorp-intranet` (bespoke text string), and
 `b31d37d4-dd59-47d3-9dd8-c973da43b63a` (UUID).


### PR DESCRIPTION
This PR is an attempt to address issue #29 by updating the domain parameter to allow for arrays of domain values.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/156.html" title="Last updated on Aug 12, 2023, 8:04 PM UTC (5aa2d86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/156/73bf77e...5aa2d86.html" title="Last updated on Aug 12, 2023, 8:04 PM UTC (5aa2d86)">Diff</a>