### PR TITLE
Add conformance classes to specification.

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,22 +425,21 @@ A <dfn>conforming secured document</dfn> is any concrete expression of the
 data model that follows the relevant normative requirements in Sections
 <a href="#proofs"></a>, <a href="#proof-purposes"></a>,
 <a href="#contexts-and-vocabularies"></a>, and
-<a href="#dataintegrityproof"></a>. Specifically,
-all relevant normative statements in those sections MUST be enforced.
+<a href="#dataintegrityproof"></a>.
         </p>
 
         <p>
 A <dfn>conforming controller document</dfn> is any concrete expression of the
-data model that follows the relevant normative requirements in Section
-<a href="#controller-documents"></a>. Specifically, all relevant normative
-statements in that section this document MUST be enforced.
+data model that follows the relevant normative requirements in Sections
+<a href="#controller-documents"></a> and
+<a href="#contexts-and-vocabularies"></a>.
         </p>
 
         <p>
 A <dfn>conforming verification method</dfn> is any concrete expression of the
 data model that follows the relevant normative requirements in Sections
-<a href="#verification-methods"></a>. Specifically, all relevant normative
-statements in that section this document MUST be enforced.
+<a href="#verification-methods"></a> and
+<a href="#contexts-and-vocabularies"></a>.
         </p>
 
         <p>
@@ -452,9 +451,17 @@ secured document</a>, a <a>conforming controller document</a>, or a
         <p>
 A <dfn class="lint-ignore">conforming cryptographic suite specification</dfn> is
 any document that follows the relevant normative requirements in Section
-<a href="#cryptographic-suites"></a>. Specifically, all relevant normative
-requirements in that section of this document MUST be implemented.
+<a href="#cryptographic-suites"></a>.
         </p>
+
+        <p>
+A <dfn class="lint-ignore">conforming processor</dfn> is any algorithm realized
+as software and/or hardware that generates or consumes a
+<a>conforming document</a> according to the relevant normative statements in
+Section <a href="#algorithms"></a>. Conforming processors MUST produce errors
+when non-conforming documents are consumed.
+        </p>
+
       </section>
 
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@ any document that follows the relevant normative requirements in Section
 
         <p>
 A <dfn class="lint-ignore">conforming processor</dfn> is any algorithm realized
-as software and/or hardware that generates or consumes a
+as software and/or hardware that generates and/or consumes a
 <a>conforming document</a> according to the relevant normative statements in
 Section <a href="#algorithms"></a>. Conforming processors MUST produce errors
 when non-conforming documents are consumed.

--- a/index.html
+++ b/index.html
@@ -448,6 +448,13 @@ A <dfn class="lint-ignore">conforming document</dfn> is either a <a>conforming
 secured document</a>, a <a>conforming controller document</a>, or a
 <a>conforming verification method</a>.
         </p>
+
+        <p>
+A <dfn class="lint-ignore">conforming cryptographic suite specification</dfn> is
+any document that follows the relevant normative requirements in Section
+<a href="#cryptographic-suites"></a>. Specifically, all relevant normative
+requirements in that section of this document MUST be implemented.
+        </p>
       </section>
 
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -420,6 +420,34 @@ applicability of the technology to their use case.
       </section>
 
       <section id="conformance">
+        <p>
+A <dfn>conforming secured document</dfn> is any concrete expression of the
+data model that follows the relevant normative requirements in Sections
+<a href="#proofs"></a>, <a href="#proof-purposes"></a>,
+<a href="#contexts-and-vocabularies"></a>, and
+<a href="#dataintegrityproof"></a>. Specifically,
+all relevant normative statements in those sections MUST be enforced.
+        </p>
+
+        <p>
+A <dfn>conforming controller document</dfn> is any concrete expression of the
+data model that follows the relevant normative requirements in Section
+<a href="#controller-documents"></a>. Specifically, all relevant normative
+statements in that section this document MUST be enforced.
+        </p>
+
+        <p>
+A <dfn>conforming verification method</dfn> is any concrete expression of the
+data model that follows the relevant normative requirements in Sections
+<a href="#verification-methods"></a>. Specifically, all relevant normative
+statements in that section this document MUST be enforced.
+        </p>
+
+        <p>
+A <dfn class="lint-ignore">conforming document</dfn> is either a <a>conforming
+secured document</a>, a <a>conforming controller document</a>, or a
+<a>conforming verification method</a>.
+        </p>
       </section>
 
       <section class="informative">


### PR DESCRIPTION
This PR attempts to address issue #159 by defining the conformance classes that are relevant to the specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/160.html" title="Last updated on Aug 12, 2023, 8:10 PM UTC (e39eacb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/160/73bf77e...e39eacb.html" title="Last updated on Aug 12, 2023, 8:10 PM UTC (e39eacb)">Diff</a>