### PR TITLE
Add `cryptosuiteString` subtype for the `cryptosuite` property.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1905,11 +1905,11 @@ such as when an undefined term is detected in an input document.
           <h3 id="cryptosuiteString">The `cryptosuiteString` Datatype</h3>
 
           <p>
-This specification encodes cryptographic identifiers as enumerable strings,
-which is useful in processes that need to efficiently encode such strings,
-such as compression algorithms. In environments that support data types for
-string values, such as RDF [[?RDF-CONCEPTS]], cryptographic identifier content
-is indicated using a literal value whose datatype is set to
+This specification encodes cryptographic suite identifiers as enumerable
+strings, which is useful in processes that need to efficiently encode such
+strings, such as compression algorithms. In environments that support data types
+for string values, such as RDF [[?RDF-CONCEPTS]], cryptographic identifier
+content is indicated using a literal value whose datatype is set to
 `https://w3id.org/security#cryptosuiteString`.
           </p>
 
@@ -1920,13 +1920,13 @@ The <code>cryptosuiteString</code> datatype is defined as follows:
           <dl>
             <dt>The URL denoting this datatype</dt>
             <dd>
-`https://w3id.org/security#cryptosuiteString`.
+`https://w3id.org/security#cryptosuiteString`
             </dd>
             <dt>The lexical space</dt>
             <dd>
 The set of all cryptosuite types, expressed using American Standard Code
-for Information Interchange [[ASCII]] strings that are defined as the set of all
-Data Integrity cryptosuite specifications.
+for Information Interchange [[ASCII]] strings, that are defined by the
+collection of all Data Integrity cryptosuite specifications.
             </dd>
             <dt>The value space</dt>
             <dd>
@@ -1936,12 +1936,13 @@ property, as defined in Section <a href="#dataintegrityproof"></a>.
             <dt>The lexical-to-value mapping</dt>
             <dd>
 Any element of the lexical space is mapped to the result of parsing it into an
-internal representation that uniquely identifies the cryptosuite value from all
-other possible cryptosuite values.
+internal representation that uniquely identifies the cryptosuite type from all
+other possible cryptosuite types.
             </dd>
             <dt>The canonical mapping</dt>
             <dd>
-Any element of the value space is mapped to the corresponding string in the lexical space.
+Any element of the value space is mapped to the corresponding string in the
+lexical space.
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -1924,13 +1924,13 @@ The <code>cryptosuiteString</code> datatype is defined as follows:
             </dd>
             <dt>The lexical space</dt>
             <dd>
-The set of all cryptosuite types, expressed using American Standard Code
+The union of all cryptosuite strings, expressed using American Standard Code
 for Information Interchange [[ASCII]] strings, that are defined by the
 collection of all Data Integrity cryptosuite specifications.
             </dd>
             <dt>The value space</dt>
             <dd>
-The set of all cryptosuite types that are expressed using the `cryptosuite`
+The union of all cryptosuite types that are expressed using the `cryptosuite`
 property, as defined in Section <a href="#dataintegrityproof"></a>.
             </dd>
             <dt>The lexical-to-value mapping</dt>

--- a/index.html
+++ b/index.html
@@ -2006,8 +2006,8 @@ The `type` property MUST contain the string `DataIntegrityProof`.
           <dt>cryptosuite</dt>
           <dd>
 The `cryptosuite` value MUST specify a string that identifies the
-<a>cryptographic suite</a>. If the processing environment supports string
-subtypes, the string subtype MUST be
+<a>cryptographic suite</a>. If the processing environment supports subtypes
+of `string`, the type of the `cryptosuite` value MUST be the `string` subtype
 `https://w3id.org/security#cryptosuiteString`.
           </dd>
           <dt>proofValue</dt>

--- a/index.html
+++ b/index.html
@@ -2005,8 +2005,10 @@ The `type` property MUST contain the string `DataIntegrityProof`.
           </dd>
           <dt>cryptosuite</dt>
           <dd>
-The `cryptosuite` property MUST contain a string specifying the name of the
-cryptosuite.
+The `cryptosuite` value MUST specify a string that identifies the
+<a>cryptographic suite</a>. If the processing environment supports string
+subtypes, the string subtype MUST be
+`https://w3id.org/security#cryptosuiteString`.
           </dd>
           <dt>proofValue</dt>
           <dd>

--- a/index.html
+++ b/index.html
@@ -1906,8 +1906,8 @@ such as when an undefined term is detected in an input document.
 
           <p>
 This specification encodes cryptographic identifiers as enumerable strings,
-which is useful in processes, such as compression algorithms, that need to
-efficiently encode such strings. In environments that support data types for
+which is useful in processes that need to efficiently encode such strings,
+such as compression algorithms. In environments that support data types for
 string values, such as RDF [[?RDF-CONCEPTS]], cryptographic identifier content
 is indicated using a literal value whose datatype is set to
 `https://w3id.org/security#cryptosuiteString`.
@@ -1920,28 +1920,28 @@ The <code>cryptosuiteString</code> datatype is defined as follows:
           <dl>
             <dt>The URL denoting this datatype</dt>
             <dd>
-is `https://w3id.org/security#cryptosuiteString`.
+`https://w3id.org/security#cryptosuiteString`.
             </dd>
             <dt>The lexical space</dt>
             <dd>
-is the set of all cryptosuite types expressed using American Standard Code
-for Information Interchange [[ASCII]] strings that are defined by the sum of all
+The set of all cryptosuite types, expressed using American Standard Code
+for Information Interchange [[ASCII]] strings that are defined as the set of all
 Data Integrity cryptosuite specifications.
             </dd>
             <dt>The value space</dt>
             <dd>
-is the set of all cryptosuite types that are expressed using the `cryptosuite`
-property as defined in Section <a href="#dataintegrityproof"></a>.
+The set of all cryptosuite types that are expressed using the `cryptosuite`
+property, as defined in Section <a href="#dataintegrityproof"></a>.
             </dd>
             <dt>The lexical-to-value mapping</dt>
             <dd>
-maps any element of the lexical space to the result of parsing it into an
+Any element of the lexical space is mapped to the result of parsing it into an
 internal representation that uniquely identifies the cryptosuite value from all
 other possible cryptosuite values.
             </dd>
             <dt>The canonical mapping</dt>
             <dd>
-maps any element of the value space to the corresponding string in the lexical space.
+Any element of the value space is mapped to the corresponding string in the lexical space.
             </dd>
           </dl>
         </section>
@@ -2050,10 +2050,10 @@ The `type` property MUST contain the string `DataIntegrityProof`.
           </dd>
           <dt>cryptosuite</dt>
           <dd>
-The `cryptosuite` value MUST specify a string that identifies the
+The value of the `cryptosuite` property MUST be a string that identifies the
 <a>cryptographic suite</a>. If the processing environment supports subtypes
-of `string`, the type of the `cryptosuite` value MUST be the `string` subtype
-`https://w3id.org/security#cryptosuiteString`.
+of `string`, the type of the `cryptosuite` value MUST be the
+`https://w3id.org/security#cryptosuiteString` subtype of `string`.
           </dd>
           <dt>proofValue</dt>
           <dd>

--- a/index.html
+++ b/index.html
@@ -1901,6 +1901,51 @@ such as when an undefined term is detected in an input document.
           </p>
         </section>
 
+        <section>
+          <h3 id="cryptosuiteString">The `cryptosuiteString` Datatype</h3>
+
+          <p>
+This specification encodes cryptographic identifiers as enumerable strings,
+which is useful in processes, such as compression algorithms, that need to
+efficiently encode such strings. In environments that support data types for
+string values, such as RDF [[?RDF-CONCEPTS]], cryptographic identifier content
+is indicated using a literal value whose datatype is set to
+`https://w3id.org/security#cryptosuiteString`.
+          </p>
+
+          <p>
+The <code>cryptosuiteString</code> datatype is defined as follows:
+          </p>
+
+          <dl>
+            <dt>The URL denoting this datatype</dt>
+            <dd>
+is `https://w3id.org/security#cryptosuiteString`.
+            </dd>
+            <dt>The lexical space</dt>
+            <dd>
+is the set of all cryptosuite types expressed using American Standard Code
+for Information Interchange [[ASCII]] strings that are defined by the sum of all
+Data Integrity cryptosuite specifications.
+            </dd>
+            <dt>The value space</dt>
+            <dd>
+is the set of all cryptosuite types that are expressed using the `cryptosuite`
+property as defined in Section <a href="#dataintegrityproof"></a>.
+            </dd>
+            <dt>The lexical-to-value mapping</dt>
+            <dd>
+maps any element of the lexical space to the result of parsing it into an
+internal representation that uniquely identifies the cryptosuite value from all
+other possible cryptosuite values.
+            </dd>
+            <dt>The canonical mapping</dt>
+            <dd>
+maps any element of the value space to the corresponding string in the lexical space.
+            </dd>
+          </dl>
+        </section>
+
       </section>
 
     </section>

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -240,7 +240,7 @@ property:
   - id: cryptosuite
     label: Cryptographic suite
     domain: sec:DataIntegrityProof
-    range: xsd:string
+    range: sec:cryptosuiteString
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-cryptosuite
 
   - id: publicKeyMultibase


### PR DESCRIPTION
This PR is an attempt to address issue #161 by adding a `cryptosuiteString` subtype for the `cryptosuite` property to ensure that it is possible to compress cryptosuite strings when performing semantic compression (CBOR-LD).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/162.html" title="Last updated on Aug 17, 2023, 6:39 PM UTC (e1ed114)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/162/3b3e64a...e1ed114.html" title="Last updated on Aug 17, 2023, 6:39 PM UTC (e1ed114)">Diff</a>