### PR TITLE
Add section on "Other" Security and Privacy Considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -3328,6 +3328,21 @@ process documents containing suspected fingerprinting URLs.
         </p>
       </section>
 
+      <section>
+        <h3>Other Privacy Considerations</h3>
+
+        <p>
+Since the technology described by this specification to secure documents is
+generalized in nature, the privacy implications of its use might not be
+immediately apparent to readers. In order to understand the sort of privacy
+concerns one might need to consider in a complete software system, implementers
+are urged to read about how this technology is utilized in the
+<a>verifiable credentials</a> ecosystem [[?VC-DATA-MODEL-2.0]]; see the section
+on <a data-cite="VC-DATA-MODEL-2.0#privacy-considerations">
+Verifiable Credential Privacy Considerations</a> for more information.
+        </p>
+      </section>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -3198,11 +3198,11 @@ from the network.
         <h3>Other Security Considerations</h3>
 
         <p>
-Since the technology described by this specification to secure documents is
+Since the technology to secure documents described by this specification is
 generalized in nature, the security implications of its use might not be
-immediately apparent to readers. In order to understand the sort of security
+immediately apparent to readers. To understand the sort of security
 concerns one might need to consider in a complete software system, implementers
-are urged to read about how this technology is utilized in the
+are urged to read about how this technology is used in the
 <a>verifiable credentials</a> ecosystem [[?VC-DATA-MODEL-2.0]]; see the section
 on <a data-cite="VC-DATA-MODEL-2.0#security-considerations">
 Verifiable Credential Security Considerations</a> for more information.
@@ -3347,11 +3347,11 @@ process documents containing suspected fingerprinting URLs.
         <h3>Other Privacy Considerations</h3>
 
         <p>
-Since the technology described by this specification to secure documents is
+Since the technology to secure documents described by this specification is
 generalized in nature, the privacy implications of its use might not be
-immediately apparent to readers. In order to understand the sort of privacy
+immediately apparent to readers. To understand the sort of privacy
 concerns one might need to consider in a complete software system, implementers
-are urged to read about how this technology is utilized in the
+are urged to read about how this technology is used in the
 <a>verifiable credentials</a> ecosystem [[?VC-DATA-MODEL-2.0]]; see the section
 on <a data-cite="VC-DATA-MODEL-2.0#privacy-considerations">
 Verifiable Credential Privacy Considerations</a> for more information.

--- a/index.html
+++ b/index.html
@@ -3194,6 +3194,21 @@ from the network.
         </p>
       </section>
 
+      <section>
+        <h3>Other Security Considerations</h3>
+
+        <p>
+Since the technology described by this specification to secure documents is
+generalized in nature, the security implications of its use might not be
+immediately apparent to readers. In order to understand the sort of security
+concerns one might need to consider in a complete software system, implementers
+are urged to read about how this technology is utilized in the
+<a>verifiable credentials</a> ecosystem [[?VC-DATA-MODEL-2.0]]; see the section
+on <a data-cite="VC-DATA-MODEL-2.0#security-considerations">
+Verifiable Credential Security Considerations</a> for more information.
+        </p>
+      </section>
+
     </section>
 
     <section>


### PR DESCRIPTION
This PR attempts to address issue #167 (raised by PING / security review) by referring back to the Security Considerations and Privacy Considerations sections in the Verifiable Credentials specification.

/cc @kdenhartog


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/173.html" title="Last updated on Aug 26, 2023, 5:21 PM UTC (3b79692)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/173/833055a...3b79692.html" title="Last updated on Aug 26, 2023, 5:21 PM UTC (3b79692)">Diff</a>