### PR TITLE
Add multibase datatype definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -1988,6 +1988,52 @@ lexical space.
           </dl>
         </section>
 
+        <section>
+          <h4 id="multibase">The `multibase` Datatype</h3>
+
+          <p>
+This specification encodes binary data into [[?MULTIBASE]]-encoded strings,
+which is useful in environments that cannot represent some binary values, such
+as ASCII-only data formats. In environments that support data types
+for string values, such as RDF [[?RDF-CONCEPTS]], [[?MULTIBASE]]-encoded
+content is indicated using a literal value whose datatype is set to
+`https://w3id.org/security#multibase`.
+          </p>
+
+          <p>
+The `multibase` datatype is defined as follows:
+          </p>
+
+          <dl>
+            <dt>The URL denoting this datatype</dt>
+            <dd>
+`https://w3id.org/security#multibase`
+            </dd>
+            <dt>The lexical space</dt>
+            <dd>
+Any string that starts with a [[?MULTIBASE]] character and where the rest of
+the characters consist of allowable characters in the respective base-encoding
+alphabet.
+            </dd>
+            <dt>The value space</dt>
+            <dd>
+Any arbitrary binary data value.
+            </dd>
+            <dt>The lexical-to-value mapping</dt>
+            <dd>
+Any element of the lexical space is mapped to the value space by base-decoding
+the value based on the associated base-decoding alphabet associated with the
+first character in the lexical string.
+            </dd>
+            <dt>The canonical mapping</dt>
+            <dd>
+Any element of the value space is mapped to the lexical space by expressing
+the desired base-encoding [[?MULTIBASE]] character first, and then base-encoding
+the value according to the desired base-encoding alphabet.
+            </dd>
+          </dl>
+        </section>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -1992,9 +1992,7 @@ lexical space.
           <h4 id="multibase">The `multibase` Datatype</h3>
 
           <p>
-This specification encodes binary data into [[?MULTIBASE]]-encoded strings,
-which is useful in environments that cannot represent some binary values, such
-as ASCII-only data formats. In environments that support data types
+[[?MULTIBASE]]-encoded strings are used to encode binary data into ASCII-only format, useful in environments that cannot directly represent binary values. This specification makes use of this encoding. In environments that support data types
 for string values, such as RDF [[?RDF-CONCEPTS]], [[?MULTIBASE]]-encoded
 content is indicated using a literal value whose datatype is set to
 `https://w3id.org/security#multibase`.
@@ -2017,13 +2015,13 @@ alphabet.
             </dd>
             <dt>The value space</dt>
             <dd>
-Any arbitrary binary data value.
+An arbitrary binary data value.
             </dd>
             <dt>The lexical-to-value mapping</dt>
             <dd>
 Any element of the lexical space is mapped to the value space by base-decoding
 the value based on the base-decoding alphabet associated with the
-first character in the lexical string.
+first  [[?MULTIBASE]] character in the lexical string.
             </dd>
             <dt>The canonical mapping</dt>
             <dd>

--- a/index.html
+++ b/index.html
@@ -2011,7 +2011,7 @@ The `multibase` datatype is defined as follows:
             </dd>
             <dt>The lexical space</dt>
             <dd>
-Any string that starts with a [[?MULTIBASE]] character and where the rest of
+Any string that starts with a [[?MULTIBASE]] character and the rest of
 the characters consist of allowable characters in the respective base-encoding
 alphabet.
             </dd>
@@ -2022,7 +2022,7 @@ Any arbitrary binary data value.
             <dt>The lexical-to-value mapping</dt>
             <dd>
 Any element of the lexical space is mapped to the value space by base-decoding
-the value based on the associated base-decoding alphabet associated with the
+the value based on the base-decoding alphabet associated with the
 first character in the lexical string.
             </dd>
             <dt>The canonical mapping</dt>

--- a/index.html
+++ b/index.html
@@ -1936,7 +1936,14 @@ such as when an undefined term is detected in an input document.
         </section>
 
         <section>
-          <h3 id="cryptosuiteString">The `cryptosuiteString` Datatype</h3>
+          <h3>Datatypes</h3>
+
+          <p>
+This section defines datatypes that are used by this specification.
+          </p>
+
+        <section>
+          <h4 id="cryptosuiteString">The `cryptosuiteString` Datatype</h3>
 
           <p>
 This specification encodes cryptographic suite identifiers as enumerable

--- a/index.html
+++ b/index.html
@@ -1992,10 +1992,12 @@ lexical space.
           <h4 id="multibase">The `multibase` Datatype</h3>
 
           <p>
-[[?MULTIBASE]]-encoded strings are used to encode binary data into ASCII-only format, useful in environments that cannot directly represent binary values. This specification makes use of this encoding. In environments that support data types
-for string values, such as RDF [[?RDF-CONCEPTS]], [[?MULTIBASE]]-encoded
-content is indicated using a literal value whose datatype is set to
-`https://w3id.org/security#multibase`.
+[[?MULTIBASE]]-encoded strings are used to encode binary data into ASCII-only
+formats, which are useful in environments that cannot directly represent binary
+values. This specification makes use of this encoding. In environments that
+support data types for string values, such as RDF [[?RDF-CONCEPTS]],
+[[?MULTIBASE]]-encoded content is indicated using a literal value whose datatype
+is set to `https://w3id.org/security#multibase`.
           </p>
 
           <p>
@@ -2025,9 +2027,7 @@ first  [[?MULTIBASE]] character in the lexical string.
             </dd>
             <dt>The canonical mapping</dt>
             <dd>
-Any element of the value space is mapped to the lexical space by expressing
-the desired base-encoding [[?MULTIBASE]] character first, and then base-encoding
-the value according to the desired base-encoding alphabet.
+The canonical mapping consists of using the lexical-to-value mapping.
             </dd>
           </dl>
         </section>

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -252,7 +252,7 @@ property:
   - id: publicKeyMultibase
     label: Public key multibase
     domain: sec:Multikey
-    range: xsd:string
+    range: sec:multibase
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-publickeymultibase
     see_also:
       - label: multibase
@@ -265,7 +265,7 @@ property:
   - id: secretKeyMultibase
     label: Secret key multibase
     domain: sec:Multikey
-    range: xsd:string
+    range: sec:multibase
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-secretkeymultibase
     see_also:
       - label: multibase format

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -197,7 +197,7 @@ property:
   - id: proofValue
     label: Proof value
     domain: sec:Proof
-    range: xsd:string
+    range: sec:multibase
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-proofvalue
 
   - id: created

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -169,7 +169,7 @@ property:
     label: Proof sets
     range: sec:ProofGraph
     defined_by: https://www.w3.org/TR/vc-data-integrity/#proof-sets
-    
+
   - id: domain
     label: Domain of a proof
     domain: sec:Proof
@@ -436,7 +436,7 @@ individual:
     upper_value: sec:ProcessingError
     label: Invalid verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD
-    
+
   - id: INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD
     upper_value: sec:ProcessingError
     label: Invalid proof purpose for verification method
@@ -447,3 +447,8 @@ datatype:
     label: Datatype for cryptosuite Identifiers
     upper_value: xsd:string
     defined_by: https://www.w3.org/TR/vc-data-integrity/#cryptosuiteString
+
+  - id: multibase
+    label: Datatype for multibase values
+    upper_value: xsd:string
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#multibase


### PR DESCRIPTION
This PR addresses https://github.com/w3c/vc-data-integrity/pull/162#discussion_r1292500235 by defining the `multibase` datatype as we recently did for `cryptosuiteString`. It then updates `proofValue`'s range to be `multibase`.

@iherman, we'll need to define the datatype in the vocabulary.yml file as well, but I didn't see how that was done for `cryptosuiteString` yet -- perhaps that still needs to be merged?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/176.html" title="Last updated on Aug 24, 2023, 9:33 PM UTC (13bb354)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/176/05112f9...13bb354.html" title="Last updated on Aug 24, 2023, 9:33 PM UTC (13bb354)">Diff</a>