### PR TITLE
Align `datetimes` to `dateTimeStamp` values to ensure timezone.

### DIFF
--- a/index.html
+++ b/index.html
@@ -579,13 +579,13 @@ by a verifier during the verification process.
           <dt><dfn class="lint-ignore">created</dfn></dt>
           <dd>
 The date and time the proof was created is OPTIONAL and, if included, MUST be
-specified as an [[XMLSCHEMA11-2]] combined date and time string.
+specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string.
           </dd>
 
           <dt><dfn class="lint-ignore">expires</dfn></dt>
           <dd>
 An OPTIONAL property that conveys the date and time that a proof expires and that, if present, MUST be
-specified as an [[XMLSCHEMA11-2]] combined date and time string.
+specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string.
           </dd>
 
           <dt id="defn-domain">domain</dt>
@@ -967,7 +967,7 @@ data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
                 <dt><dfn class="lint-ignore">revoked</dfn></dt>
                 <dd>
 The `revoked` property is OPTIONAL. If provided, it MUST be an [[XMLSCHEMA11-2]]
-combined date and time string specifying when the <a>verification method</a>
+`dateTimeStamp` string specifying when the <a>verification method</a>
 SHOULD cease to be used. Once the value is set, it is not expected to be updated, and
 systems depending on the value are expected to not verify any proofs associated
 with the <a>verification method</a> at or after the time of revocation.
@@ -2163,8 +2163,8 @@ which  can be used to verify the authenticity and integrity of an
 <a>cryptographic suite</a> (<var>type</var>) and any other properties needed by
 the <a>cryptographic suite</a> type; an identifier for the
 <a>verification method</a> (<var>verificationMethod</var>) that can be used to
-verify the authenticity of the proof; an [[!XMLSCHEMA11-2]] combined date
-and time string (<var>created</var>) containing the current date and time,
+verify the authenticity of the proof; an [[!XMLSCHEMA11-2]] `dateTimeStamp`
+string (<var>created</var>) containing the current date and time,
 accurate to at least one second, in Universal Time Code format. A
 <a href="#dfn-domain">security domain</a> (<var>domain</var>) and/or a
 receiver-supplied challenge (<var>challenge</var>) MAY also be specified in


### PR DESCRIPTION
This PR attempts to align the way datetime values are used in this specification with the way they are used in the vc-data-model, namely, ensuring that a `dateTimeStamp` value is used (which ensures that a timezone is specified when expressing a datetime). 

VC v1.0 and v1.1 didn't do this and there were a few instances where systems were creating datetime values that did not include a timezone (and thus were ambiguous because interpreting the time was done using the local timezone... and if a datetime was set in one timezone, there could be a misinterpretation of the datetime value when interpreted in another timezone).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/178.html" title="Last updated on Aug 24, 2023, 8:58 PM UTC (8fd52e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/178/4a82497...8fd52e2.html" title="Last updated on Aug 24, 2023, 8:58 PM UTC (8fd52e2)">Diff</a>