### PR TITLE
Add `revoked` and `expires` properties to JsonWebKey context.

### DIFF
--- a/contexts/jwk/v1
+++ b/contexts/jwk/v1
@@ -13,6 +13,14 @@
           "@id": "https://w3id.org/security#controller",
           "@type": "@id"
         },
+        "revoked": {
+          "@id": "https://w3id.org/security#revoked",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
         "publicKeyJwk": {
           "@id": "https://w3id.org/security#publicKeyJwk",
           "@type": "@json"

--- a/index.html
+++ b/index.html
@@ -996,13 +996,28 @@ Registries [TBD -- DIS-REGISTRIES].
 The value of the `controller` property MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
                 </dd>
+                <dt><dfn class="lint-ignore">expires</dfn></dt>
+                <dd>
+The `expires` property is OPTIONAL. It is set, in advance, by the
+<a>controller</a> of a  <a>verification method</a> to signal when that method
+can no longer be used for verification purposes. If provided, it MUST be an
+[[XMLSCHEMA11-2]] `dateTimeStamp` string specifying when the
+<a>verification method</a> SHOULD cease to be used. Once the value is set, it is
+not expected to be updated, and systems depending on the value are expected to
+not verify any proofs associated with the <a>verification method</a> at or after
+the time of expiration.
+                </dd>
                 <dt><dfn class="lint-ignore">revoked</dfn></dt>
                 <dd>
-The `revoked` property is OPTIONAL. If provided, it MUST be an [[XMLSCHEMA11-2]]
+The `revoked` property is OPTIONAL. It is set by the <a>controller</a> of a
+<a>verification method</a> to signal when that method is to no longer to be used
+for verification purposes, such as after a security compromise of the
+<a>verification method</a>. If provided, it MUST be an [[XMLSCHEMA11-2]]
 `dateTimeStamp` string specifying when the <a>verification method</a>
-SHOULD cease to be used. Once the value is set, it is not expected to be updated, and
-systems depending on the value are expected to not verify any proofs associated
-with the <a>verification method</a> at or after the time of revocation.
+SHOULD cease to be used. Once the value is set, it is not expected to be
+updated, and systems depending on the value are expected to not verify any
+proofs associated with the <a>verification method</a> at or after the time of
+revocation.
                 </dd>
               </dl>
             </dd>

--- a/index.html
+++ b/index.html
@@ -1949,6 +1949,23 @@ href="#proofs">proof</a>, or the validity period for the
 <a data-cite="?VC-DATA-MODEL-2.0#dfn-credential">credential</a>, might result
 in accepting data that ought to have been rejected.
         </p>
+
+        <p>
+Finally, implementers are also urged to understand that there is a difference
+between the <a href="#dfn-revoked">revocation time</a> and
+<a href="#defn-vm-expires">expiration time</a> for a <a>verification method</a>,
+and the revocation information associated with a <a>verifiable credential</a>.
+The <a href="#dfn-revoked">revocation time</a> and
+<a href="#defn-vm-expires">expiration time</a> for a <a>verification method</a>
+are expressed using the `revocation` and `expires` properties, respectively, and
+are related to events such as a private key being compromised or expiring and
+can provide timing information which might reveal details about a controller
+such as their security practices or when they might have been compromised. The
+revocation information for a <a>verifiable credential</a> is expressed using
+the `credentialStatus` property and is related to events such as an individual
+losing the privilege that is granted by the <a>verifiable credential</a> and
+does not provide timing information, which enhances privacy.
+        </p>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -616,9 +616,8 @@ specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string.
 
           <dt id="defn-proof-expires">expires</dt>
           <dd>
-An OPTIONAL property that conveys the date and time that a proof expires and
-that, if present, MUST be specified as an [[XMLSCHEMA11-2]] combined date and
-time string.
+The `expires` property is OPTIONAL. If present, it MUST be an [[XMLSCHEMA11-2]]
+`dateTimeStamp` string specifying when the proof expires.
           </dd>
 
           <dt id="defn-domain">domain</dt>

--- a/index.html
+++ b/index.html
@@ -614,10 +614,11 @@ The date and time the proof was created is OPTIONAL and, if included, MUST be
 specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string.
           </dd>
 
-          <dt><dfn class="lint-ignore">expires</dfn></dt>
+          <dt id="defn-proof-expires">expires</dt>
           <dd>
-An OPTIONAL property that conveys the date and time that a proof expires and that, if present, MUST be
-specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string.
+An OPTIONAL property that conveys the date and time that a proof expires and
+that, if present, MUST be specified as an [[XMLSCHEMA11-2]] combined date and
+time string.
           </dd>
 
           <dt id="defn-domain">domain</dt>
@@ -996,7 +997,7 @@ Registries [TBD -- DIS-REGISTRIES].
 The value of the `controller` property MUST be a <a
 data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
                 </dd>
-                <dt><dfn class="lint-ignore">expires</dfn></dt>
+                <dt id="defn-vm-expires">expires</dt>
                 <dd>
 The `expires` property is OPTIONAL. It is set, in advance, by the
 <a>controller</a> of a  <a>verification method</a> to signal when that method
@@ -1925,8 +1926,8 @@ the proof.
 Document authors and implementers are advised to understand the difference
 between the validity period of a <a href="#proofs">proof</a>, which is expressed
 using the <a href="#dfn-created">`created`</a> and <a
-href="#dfn-expires">`expires`</a> properties, and the validity period of a
-<a data-cite="?VC-DATA-MODEL-2.0#dfn-credential">credential</a>,
+href="#defn-proof-expires">`expires`</a> properties, and the validity period of
+a <a data-cite="?VC-DATA-MODEL-2.0#dfn-credential">credential</a>,
 which is expressed using the
 <a data-cite="?VC-DATA-MODEL-2.0#defn-validFrom">`validFrom`</a> and
 <a data-cite="?VC-DATA-MODEL-2.0#defn-validUntil">`validUntil`</a> properties.
@@ -1935,7 +1936,8 @@ other times they might not be aligned. When verifying a
 <a href="#proofs">proof</a>, it is important to ensure that the time of interest
 (which might be the current time or any other time) is within the
 validity period for the proof (that is, between
-<a href="#dfn-created">`created`</a> and <a href="#dfn-expires">`expires`</a> ).
+<a href="#dfn-created">`created`</a> and
+<a href="#defn-proof-expires">`expires`</a> ).
 When <a data-cite="?VC-DATA-MODEL-2.0#validation">validating</a> a
 <a>verifiable credential</a>, it is important to ensure that the time of
 interest is within the validity period for the

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -207,9 +207,11 @@ property:
     range: xsd:dateTime
 
   - id: expires
-    label: Proof expiration time
-    defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-expires
-    domain: sec:Proof
+    label: Expiration time for a proof or verification method
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires
+    domain:
+      - sec:Proof
+      - sec:VerificationMethod
     range: xsd:dateTime
 
   - id: nonce


### PR DESCRIPTION
This PR attempts to address issue #182 by adds the `revoked` and `expires` properties to JsonWebKey context. It also differentiates the anchors for `expires` on `proof` and `verificationMethod`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/184.html" title="Last updated on Sep 2, 2023, 2:57 PM UTC (c4aede2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/184/0a64834...c4aede2.html" title="Last updated on Sep 2, 2023, 2:57 PM UTC (c4aede2)">Diff</a>