### PR TITLE
Ensure that base URL is set to null when processing as RDF.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2147,7 +2147,7 @@ such as when an undefined term is detected in an input document.
 Similarly, since <a>conforming secured documents</a> can be transferred from one
 security domain to another, <a>conforming processors</a> that process the
 <a>conforming secured document</a> cannot assume any particular base URL for
-the document. When serializing to RDF, implementations MUST ensure that the
+the document. When deserializing to RDF, implementations MUST ensure that the
 base URL is set to null.
           </p>
         </section>

--- a/index.html
+++ b/index.html
@@ -2142,6 +2142,14 @@ Canonicalization [[?RDF-CANON]], MUST throw an error, which SHOULD be
 `DATA_LOSS_DETECTION_ERROR`, when data is dropped by a JSON-LD processor,
 such as when an undefined term is detected in an input document.
           </p>
+
+          <p>
+Similarly, since <a>conforming secured documents</a> can be transferred from one
+security domain to another, <a>conforming processors</a> that process the
+<a>conforming secured document</a> cannot assume any particular base URL for
+the document. When serializing to RDF, implementations MUST ensure that the
+base URL is set to null.
+          </p>
         </section>
 
         <section>


### PR DESCRIPTION
This PR attempts to address issue #180 by ensuring that the base URL is set to null when processing as RDF.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/185.html" title="Last updated on Sep 2, 2023, 3:15 PM UTC (917c4dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/185/00bd146...917c4dc.html" title="Last updated on Sep 2, 2023, 3:15 PM UTC (917c4dc)">Diff</a>