### PR TITLE
Update status of Multibase and Multihash at IETF.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1843,7 +1843,7 @@ guaranteed between implementations.
 The [[?MULTIBASE]] and [[?MULTIHASH]] specifications have been dispatched at
 IETF and may be standardized. There is active discussion on this initiative in
 the <a href="https://mailarchive.ietf.org/arch/browse/multiformats/">
-Multiformats mailing list at IETF</a>. If the specifications are stabilized
+Multiformats mailing list at IETF</a>. If those specifications are stabilized
 before this specification goes to the Proposed Recommendation phase, the tables
 above will be replaced with normative references to the Multibase and Multihash
 specifications.

--- a/index.html
+++ b/index.html
@@ -1839,13 +1839,13 @@ Other Multihash encoding values MAY be used, but interoperability is not
 guaranteed between implementations.
         </p>
 
-        <p class="issue atrisk" title="Multibase and Multihash are being standardized at IETF">
-The [[?MULTIBASE]] and [[?MULTIHASH]] specifications have been dispatched at IETF
-to be standardized in a
-<a href="https://mailarchive.ietf.org/arch/browse/multiformats/">
-Multiformats Working Group</a>. If the specifications are stabilized before this
-specification goes to the Proposed Recommendation phase, the tables above will
-be replaced with normative references to the Multibase and Multihash
+        <p class="issue atrisk" title="Multibase and Multihash may be standardized at IETF">
+The [[?MULTIBASE]] and [[?MULTIHASH]] specifications have been dispatched at
+IETF and may be standardized. There is active discussion on this initiative in
+the <a href="https://mailarchive.ietf.org/arch/browse/multiformats/">
+Multiformats mailing list at IETF</a>. If the specifications are stabilized
+before this specification goes to the Proposed Recommendation phase, the tables
+above will be replaced with normative references to the Multibase and Multihash
 specifications.
         </p>
 


### PR DESCRIPTION
This PR addresses issue #192 by updating the text regarding the current status of Multibase and Multihash at IETF.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/197.html" title="Last updated on Sep 25, 2023, 3:14 PM UTC (1da7cf8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/197/9493324...1da7cf8.html" title="Last updated on Sep 25, 2023, 3:14 PM UTC (1da7cf8)">Diff</a>