### PR TITLE
Add sections on security/privacy and c14n method selection.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3677,7 +3677,7 @@ information in a secured document, nor does it utilize JSON-LD, then JSON
 Canonicalization Scheme [[RFC8785]] is an attractive approach.
         </p>
         <p>
-If an application uses JSON-LD and/or might require selective disclosure
+If an application uses JSON-LD and might require selective disclosure
 of information in a secured document, then using a cryptography suite that
 uses RDF Dataset Canonicalization [[RDF-CANON]] is an attractive
 approach.

--- a/index.html
+++ b/index.html
@@ -197,6 +197,17 @@
               ],
               status: "National Standard",
               publisher: "U.S. Department of Commerce"
+            },
+            "SD-JWT": {
+              title:    "Selective Disclosure for JWTs (SD-JWT)",
+              href:     "https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/",
+              authors: [
+                "Daniel Fett",
+                "Kristina Yasuda",
+                "Brian Campbell"
+              ],
+              status:   "I-D",
+              publisher:  "The IETF OAuth Working Group"
             }
           },
           postProcess: [restrictRefs],
@@ -3399,7 +3410,7 @@ website as the proof creator if the website erroneously accepted such a proof as
         <h3>Canonicalization Method Security</h3>
 
         <p>
-The way in which a transformation, namely canonicalization, is performed can
+The way in which a transformation, such as canonicalization, is performed can
 affect the security characteristics of a system. Selecting the best
 canonicalization mechanisms depends on the use case. Often,
 the simplest mechanism that satisfies the desired security requirements
@@ -3418,6 +3429,14 @@ If an application uses JSON-LD and needs to secure the semantics of
 the document, then using a cryptography suite that
 uses RDF Dataset Canonicalization [[RDF-CANON]] is an attractive
 approach.
+        </p>
+        <p>
+Implementers are also advised that other mechanisms that perform no
+transformations are available, that secure the data by wrapping it in a
+cryptographic envelope instead of embedding the proof in the data, such as
+JWTs [[?RFC7519]] and CWTs [[?RFC8392]]. These approaches have simplicity
+advantages in some use cases, at the expense of some of the benefits provided
+by the approach detailed in this specification.
         </p>
       </section>
 
@@ -3662,6 +3681,14 @@ If an application uses JSON-LD and/or might require selective disclosure
 of information in a secured document, then using a cryptography suite that
 uses RDF Dataset Canonicalization [[RDF-CANON]] is an attractive
 approach.
+        </p>
+        <p>
+Implementers are also advised that other selective disclosure mechanisms that
+perform no transformations are available, that secure the data by wrapping it in a
+cryptographic envelope instead of embedding the proof in the data, such as
+SD-JWTs [[?SD-JWT]]. This approach has simplicity advantages in some use cases,
+at the expense of some of the benefits provided by the approach detailed in
+this specification.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -3399,24 +3399,24 @@ website as the proof creator if the website erroneously accepted such a proof as
         <h3>Canonicalization Method Security</h3>
 
         <p>
-The way in which transformation, namely canonicalization, is performed can
-affect the security characteristics of a system. Selecting among these
-canonicalization mechanisms is dependent on the use case being addressed. Often,
-selecting the simplest mechanism that achieves the desired security requirements
+The way in which a transformation, namely canonicalization, is performed can
+affect the security characteristics of a system. Selecting the best
+canonicalization mechanisms depends on the use case. Often,
+the simplest mechanism that satisfies the desired security requirements
 is the best choice. This section attempts to provide simple guidance to help
-implementers pick between the two main canonicalization mechanisms referred to
+implementers choose between the two main canonicalization mechanisms referred to
 in this specification, namely JSON Canonicalization Scheme [[RFC8785]] and
 RDF Dataset Canonicalization [[RDF-CANON]].
         </p>
         <p>
-If an application only utilizes JSON and does not depend on any form of RDF
-semantics, then utilizing a cryptography suite that utilizes JSON
-Canonicalization Scheme [[RFC8785]] is most likely the best approach.
+If an application only uses JSON and does not depend on any form of RDF
+semantics, then using a cryptography suite that uses JSON
+Canonicalization Scheme [[RFC8785]] is an attractive approach.
         </p>
         <p>
-If an application utilizes JSON-LD and needs to ensure that the semantics of
-the document are being secured, then utilizing a cryptography suite that
-utilizes RDF Dataset Canonicalization [[RDF-CANON]] is most likely the best
+If an application uses JSON-LD and needs to secure the semantics of
+the document, then using a cryptography suite that
+uses RDF Dataset Canonicalization [[RDF-CANON]] is an attractive
 approach.
         </p>
       </section>
@@ -3644,9 +3644,9 @@ process documents containing suspected fingerprinting URLs.
         <h3>Canonicalization Method Privacy</h3>
 
         <p>
-The way in which transformation, namely canonicalization, is performed can
-affect the privacy characteristics of a system. Selecting among these
-canonicalization mechanisms is dependent on the use case being addressed.
+The way in which a transformation, namely canonicalization, is performed can
+affect the privacy characteristics of a system. Selecting the best
+canonicalization mechanism depends on the use case.
 This section attempts to provide simple guidance to help
 implementers pick between the two main canonicalization mechanisms referred to
 in this specification, namely JSON Canonicalization Scheme [[RFC8785]] and
@@ -3655,12 +3655,12 @@ RDF Dataset Canonicalization [[RDF-CANON]], from a privacy perspective.
         <p>
 If an application does not require performing a selective disclosure of
 information in a secured document, nor does it utilize JSON-LD, then JSON
-Canonicalization Scheme [[RFC8785]] is most likely the best approach.
+Canonicalization Scheme [[RFC8785]] is an attractive approach.
         </p>
         <p>
-If an application utilizes JSON-LD or might require the selective disclosure
+If an application uses JSON-LD and/or might require selective disclosure
 of information in a secured document, then using a cryptography suite that
-utilizes RDF Dataset Canonicalization [[RDF-CANON]] is most likely the best
+uses RDF Dataset Canonicalization [[RDF-CANON]] is an attractive
 approach.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -3396,6 +3396,32 @@ website as the proof creator if the website erroneously accepted such a proof as
       </section>
 
       <section>
+        <h3>Canonicalization Method Security</h3>
+
+        <p>
+The way in which transformation, namely canonicalization, is performed can
+affect the security characteristics of a system. Selecting among these
+canonicalization mechanisms is dependent on the use case being addressed. Often,
+selecting the simplest mechanism that achieves the desired security requirements
+is the best choice. This section attempts to provide simple guidance to help
+implementers pick between the two main canonicalization mechanisms referred to
+in this specification, namely JSON Canonicalization Scheme [[RFC8785]] and
+RDF Dataset Canonicalization [[RDF-CANON]].
+        </p>
+        <p>
+If an application only utilizes JSON and does not depend on any form of RDF
+semantics, then utilizing a cryptography suite that utilizes JSON
+Canonicalization Scheme [[RFC8785]] is most likely the best approach.
+        </p>
+        <p>
+If an application utilizes JSON-LD and needs to ensure that the semantics of
+the document are being secured, then utilizing a cryptography suite that
+utilizes RDF Dataset Canonicalization [[RDF-CANON]] is most likely the best
+approach.
+        </p>
+      </section>
+
+      <section>
         <h3>Canonicalization Method Correctness</h3>
 
         <p>
@@ -3611,6 +3637,31 @@ might be used to determine whether creators of <a>conforming documents</a> are
 using fingerprinting URLs in a way that might violate privacy expectations.
 These heuristics could be used to display warnings to entities that might
 process documents containing suspected fingerprinting URLs.
+        </p>
+      </section>
+
+      <section>
+        <h3>Canonicalization Method Privacy</h3>
+
+        <p>
+The way in which transformation, namely canonicalization, is performed can
+affect the privacy characteristics of a system. Selecting among these
+canonicalization mechanisms is dependent on the use case being addressed.
+This section attempts to provide simple guidance to help
+implementers pick between the two main canonicalization mechanisms referred to
+in this specification, namely JSON Canonicalization Scheme [[RFC8785]] and
+RDF Dataset Canonicalization [[RDF-CANON]], from a privacy perspective.
+        </p>
+        <p>
+If an application does not require performing a selective disclosure of
+information in a secured document, nor does it utilize JSON-LD, then JSON
+Canonicalization Scheme [[RFC8785]] is most likely the best approach.
+        </p>
+        <p>
+If an application utilizes JSON-LD or might require the selective disclosure
+of information in a secured document, then using a cryptography suite that
+utilizes RDF Dataset Canonicalization [[RDF-CANON]] is most likely the best
+approach.
         </p>
       </section>
 


### PR DESCRIPTION
This PR attempts to address issue #194 and #195 by adding guidance on selecting canonicalization mechanisms, from a security and privacy perspective, as requested by the horizontal reviews performed on the vc-data-integrity specification.

/cc @kdenhartog


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/199.html" title="Last updated on Sep 25, 2023, 3:56 PM UTC (c3ffc66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/199/6a3317a...c3ffc66.html" title="Last updated on Sep 25, 2023, 3:56 PM UTC (c3ffc66)">Diff</a>