### PR TITLE
[Editorial] Making the diagram dark-mode safe

### DIFF
--- a/vocab/security/README.md
+++ b/vocab/security/README.md
@@ -2,11 +2,15 @@
 
 The script in the directory generates RDFS vocabulary files in JSON and Turtle formats, plus a human readable HTML file containing the vocabulary in RDFa, based on a simple vocabulary definition in a YAML file. This is done using the [yml2vocab](https://github.com/w3c/yml2vocab); more details about the script can also be found in the [yml2vocab readme file](https://github.com/w3c/yml2vocab).
 
+The generation of the final files is done via a github action (see `/.github/workflows/gh-pages.yml`).
 
 ## Content of the directory
 
 - `Readme.md`: this file.
-- `vocabulary.yml`: the core vocabulary specification. _Any change on the vocabulary must be made by modifying this file;_ see the separate [description](https://github.com/w3c/yml2vocab) of the underlying YAML format, and the way to generate the "real", outward facing facing vocabulary files.
-- `vocabulary.ttl`, `vocabulary.jsonld`, `vocabulary.html`: the vocabulary specification in Turtle, JSON-LD, and HTML+RDFa, respectively. _These files are generated; they should not be modified manually._
-- `template.json`: an HTML template file used by the script; it is the skeleton of the final HTML format based on [ReSpec](https://respec.org/docs/). If the file is modified, care should be taken not to change the core structure and the various, possibly empty, HTML elements with `@id` values. The script fills those elements with content when generating the `vocabulary.html` file.
+- `vocabulary.yml`: the core vocabulary specification. _Any change on the vocabulary must be made by modifying this file;_ see the separate [description](https://github.com/w3c/yml2vocab) of the underlying YAML format.
+- `vocabulary.drawio`: the vocabulary diagram in the [draw.io](https://www.drawio.com/) format. _Any change on the vocabulary diagram must be made by modifying this file._ 
+  
+    The corresponding application can be downloaded and used directly, or added to Google Docs. Note that, due to some bug in the software the exported SVG file must be ran through a [post-processing script](https://github.com/iherman/drawio-svg/), to be downloaded and run separately.
+- `vocabulary.svg`: the SVG file for the vocabulary, generated from `vocabulary.drawio`.
+- `template.json`: an HTML template file used by the script; it is the skeleton of the final HTML format based on [ReSpec](https://respec.org/docs/). If the file is modified, care should be taken not to change the core structure and the various, possibly empty, HTML elements with `@id` values. The script fills those elements with content when generating the `vocabulary.html` file (and removes any sections that remain empty after processing).
 

--- a/vocab/security/vocabulary.drawio
+++ b/vocab/security/vocabulary.drawio
@@ -1,0 +1,567 @@
+<mxfile host="Electron" modified="2023-10-12T14:30:41.575Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.0.2 Chrome/114.0.5735.289 Electron/25.8.4 Safari/537.36" etag="TJvEIaUR1NyFUIpCFM_F" version="22.0.2" type="device">
+  <diagram name="Page-1" id="hQ0IBVJ5jpEcegRt-_B3">
+    <mxGraphModel dx="1710" dy="1142" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-115" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="127" y="812.5" width="1340" height="54.5" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-84" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" parent="Uf8WLKuzS3drS_BCJ-BJ-115" vertex="1">
+          <mxGeometry width="1330" height="54.5" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-114" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-115" vertex="1" connectable="0">
+          <mxGeometry x="11.5" y="7.25" width="1328.5" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-108" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
+          <mxGeometry x="1138.5" width="190" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-109" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;endArrow=classic;endFill=0;" parent="Uf8WLKuzS3drS_BCJ-BJ-108" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="84" y="19.5" as="sourcePoint" />
+            <mxPoint x="157" y="19.72" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-110" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Graph containment&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;" parent="Uf8WLKuzS3drS_BCJ-BJ-108" vertex="1">
+          <mxGeometry y="-6" width="70" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-87" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
+          <mxGeometry y="1.4375" width="160" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-88" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-87" vertex="1">
+          <mxGeometry x="60" y="4.95" width="100" height="28.004625" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-89" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-87" vertex="1">
+          <mxGeometry width="50" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-90" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
+          <mxGeometry x="187.5" y="1.4375" width="170" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-91" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#330000;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-90" vertex="1">
+          <mxGeometry x="83" y="4.95" width="80" height="23.685750000000002" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-92" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-90" vertex="1">
+          <mxGeometry width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-93" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
+          <mxGeometry x="571.5" y="1.4375" width="170" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-94" value="" style="endArrow=classic;html=1;rounded=0;endFill=1;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-93" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="87" y="17.94375" as="sourcePoint" />
+            <mxPoint x="167" y="18.5625" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-95" value="Superclass" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-93" vertex="1">
+          <mxGeometry x="-5" width="80" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-96" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
+          <mxGeometry x="781.5" y="1.4375" width="136" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-97" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=none;startFill=0;endArrow=classic;endFill=1;strokeColor=#FF3333;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;dashPattern=1 1;" parent="Uf8WLKuzS3drS_BCJ-BJ-96" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="74" y="18.5625" as="sourcePoint" />
+            <mxPoint x="154" y="18.5625" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="130" y="18.5625" />
+              <mxPoint x="130" y="18.5625" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-98" value="Domain" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-96" vertex="1">
+          <mxGeometry width="60" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-99" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
+          <mxGeometry x="961.5" y="1.4375" width="160" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-100" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#0000CC;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-99" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="67" y="18.5625" as="sourcePoint" />
+            <mxPoint x="147" y="18.5625" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-101" value="Range" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-99" vertex="1">
+          <mxGeometry width="60" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-113" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
+          <mxGeometry x="382.5" width="163.39999999999998" height="40" as="geometry" />
+        </mxCell>
+        <UserObject label="" id="Uf8WLKuzS3drS_BCJ-BJ-111">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-113" vertex="1">
+            <mxGeometry x="75" y="11.5" width="88.4" height="17" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-112" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" parent="Uf8WLKuzS3drS_BCJ-BJ-113" vertex="1">
+          <mxGeometry width="90" height="40" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;VerificationMethod&lt;/i&gt;" link="https://w3id.org/security/#VerificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="1104.668136020151" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;controller&lt;/i&gt;" link="https://w3id.org/security/#controller" id="Uf8WLKuzS3drS_BCJ-BJ-44">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="868.003765743073" y="298.9969117647059" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;revoked&lt;/i&gt;" link="https://w3id.org/security/#revoked" id="Uf8WLKuzS3drS_BCJ-BJ-45">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="868.003765743073" y="347.99470588235295" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-48" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-38" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1092.2207178841309" y="192.87113309466875" as="sourcePoint" />
+            <mxPoint x="1206.1624685138538" y="192.87113309466875" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1328" y="100" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-49" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-39" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1140.0954030226699" y="183.30157427113934" as="sourcePoint" />
+            <mxPoint x="1254.0371536523928" y="183.30157427113934" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1318" y="120" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-50" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-40" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1140.0954030226699" y="202.44069191819818" as="sourcePoint" />
+            <mxPoint x="1254.0371536523928" y="202.44069191819818" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1328" y="150" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-51" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-41" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1140.0954030226699" y="278.9971625064335" as="sourcePoint" />
+            <mxPoint x="1254.0371536523928" y="278.9971625064335" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1318" y="170" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-52" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-42" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1197.5450251889167" y="326.84495662408057" as="sourcePoint" />
+            <mxPoint x="1311.4867758186397" y="326.84495662408057" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1308" y="200" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-53" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-43" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1152.0640743073047" y="384.07091838878637" as="sourcePoint" />
+            <mxPoint x="1266.0058249370275" y="384.07091838878637" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1298" y="230" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-54" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-44" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1394.7887279596976" y="336.2258823529412" as="sourcePoint" />
+            <mxPoint x="1216.6948992443324" y="336.2258823529412" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1128" y="140" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-55" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-45" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1509.6879722921913" y="345.7954411764706" as="sourcePoint" />
+            <mxPoint x="1331.5941435768261" y="345.7954411764706" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1148" y="180" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;Ed25519VerificationKey2020&lt;/i&gt;" link="https://w3id.org/security/#Ed25519VerificationKey2020" id="Uf8WLKuzS3drS_BCJ-BJ-56">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="1099.67" y="390" width="227.68" height="46.89" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-78" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeWidth=2;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-57" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1088.3907430730478" y="412.7823529411765" as="sourcePoint" />
+            <mxPoint x="1250.2071788413098" y="412.81106161764706" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1218" y="300" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-79" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeWidth=2;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-56" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1232.0147984886648" y="393.64323529411763" as="sourcePoint" />
+            <mxPoint x="1393.8312342569268" y="393.6719439705882" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-80" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;strokeWidth=2;entryX=0.5;entryY=1;entryDx=0;entryDy=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-58" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1442.6634130982368" y="431.9214705882353" as="sourcePoint" />
+            <mxPoint x="1336.38161209068" y="384.10238514705884" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1209" y="290" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;Proof&lt;/i&gt;" link="https://w3id.org/security/#Proof" id="Uf8WLKuzS3drS_BCJ-BJ-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;pointer-events=&quot;all&quot;" parent="1" vertex="1">
+            <mxGeometry x="234.92600755667502" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;ProofGraph&lt;/i&gt;" link="https://w3id.org/security/#ProofGraph" id="Uf8WLKuzS3drS_BCJ-BJ-2">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="62.57714105793451" y="163.97382352941176" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-3" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;endArrow=classic;endFill=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-2" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="254.07588161209065" y="128.56645588235295" as="sourcePoint" />
+            <mxPoint x="464.72449622166243" y="125.69558823529412" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;proof&lt;/i&gt;" link="https://w3id.org/security/#proof" id="Uf8WLKuzS3drS_BCJ-BJ-5">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="85.55698992443325" y="317.08676470588233" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-6" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=1;entryDx=0;entryDy=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-5" target="Uf8WLKuzS3drS_BCJ-BJ-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="301.9505667506297" y="259.8580448593747" as="sourcePoint" />
+            <mxPoint x="415.8923173803526" y="259.8580448593747" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;domain&lt;/i&gt;" link="https://w3id.org/security/#domain" id="Uf8WLKuzS3drS_BCJ-BJ-7">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="555.3489294710328" y="143" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;challenge&lt;/i&gt;" link="https://w3id.org/security/#challenge" id="Uf8WLKuzS3drS_BCJ-BJ-8">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="555.3489294710328" y="248" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;previousProof&lt;/i&gt;" link="https://w3id.org/security/#previousProof" id="Uf8WLKuzS3drS_BCJ-BJ-9">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="555.3489294710328" y="96.8925" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;proofPurpose&lt;br&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#proofPurpose" id="Uf8WLKuzS3drS_BCJ-BJ-10">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="555.3489294710328" y="299.15" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;proofValue&lt;/i&gt;" link="https://w3.org/2018/credentials/#proofValue" id="Uf8WLKuzS3drS_BCJ-BJ-11">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="555.3489294710328" y="440.29808823529413" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;expires&lt;/i&gt;" link="https://w3.org/2018/credentials/#expires" id="Uf8WLKuzS3drS_BCJ-BJ-12">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="867.9989294710327" y="247" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;nonce&lt;/i&gt;" link="https://w3.org/2018/credentials/#nonce" id="Uf8WLKuzS3drS_BCJ-BJ-13">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="555.3489294710328" y="347" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;created&lt;/i&gt;" link="https://w3.org/2018/credentials/#created" id="Uf8WLKuzS3drS_BCJ-BJ-14">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="555.3489294710328" y="394" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-15" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-7" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="441.7446473551637" y="163.97382352941176" as="sourcePoint" />
+            <mxPoint x="263.65081863979844" y="163.97382352941176" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="478" y="120" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-16" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;entryX=1;entryY=1;entryDx=0;entryDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-8" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="493.44930730478586" y="122.8247205882353" as="sourcePoint" />
+            <mxPoint x="330.6753778337531" y="106.5564705882353" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="478" y="150" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-17" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-9" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="480.04439546599497" y="183.1129411764706" as="sourcePoint" />
+            <mxPoint x="301.9505667506297" y="183.1129411764706" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="508" y="100" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-18" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-10" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="503.0242443324937" y="132.3942794117647" as="sourcePoint" />
+            <mxPoint x="358.44269521410575" y="96.02995588235294" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="493.44930730478586" y="202.2520588235294" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-19" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-11" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="422.5947732997481" y="259.6694117647059" as="sourcePoint" />
+            <mxPoint x="244.50094458438286" y="259.6694117647059" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="408" y="260" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-20" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-12" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="868.3089294710326" y="227.1282500000002" as="sourcePoint" />
+            <mxPoint x="413.9768556909135" y="69.89352290842726" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="538" y="230" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-21" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-13" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="541.3239924433249" y="403.21279411764704" as="sourcePoint" />
+            <mxPoint x="273.2257556675063" y="269.2389705882353" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="448" y="270" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-22" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-14" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="441.7446473551637" y="288.3780882352941" as="sourcePoint" />
+            <mxPoint x="263.65081863979844" y="288.3780882352941" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="438" y="290" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;DataIntegrityProof&lt;/i&gt;" link="https://w3id.org/security/#DataIntegrityProof" id="Uf8WLKuzS3drS_BCJ-BJ-23">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="234.92600755667502" y="460.6301470588235" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;Ed25519Signature2020&lt;/i&gt;" link="https://w3id.org/security/#Ed25519Signature2020" id="Uf8WLKuzS3drS_BCJ-BJ-24">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="8" y="460.6301470588235" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-25" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeWidth=2;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-23" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="690.6930100755667" y="441.4910294117647" as="sourcePoint" />
+            <mxPoint x="852.5094458438286" y="441.5197380882353" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-26" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.83;exitY=0.122;exitDx=0;exitDy=0;strokeWidth=2;exitPerimeter=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-24" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="709.8428841309824" y="585.034411764706" as="sourcePoint" />
+            <mxPoint x="871.6593198992443" y="585.0631204411765" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="336.42034005037783" y="326.6563235294118" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;cryptosuite&lt;/i&gt;" link="https://w3id.org/security/#cryptosuite" id="Uf8WLKuzS3drS_BCJ-BJ-27">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="257.90585642317376" y="559.1966029411765" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="cryptosuiteString" link="https://w3id.org/security/#cryptosuiteString" id="Uf8WLKuzS3drS_BCJ-BJ-29">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="264.60831234256926" y="652.0213235294117" width="149.3690176322418" height="28.708676470588237" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-30" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-29" target="Uf8WLKuzS3drS_BCJ-BJ-29" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-31" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-27" target="Uf8WLKuzS3drS_BCJ-BJ-23" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="677.2880982367758" y="546.7561764705882" as="sourcePoint" />
+            <mxPoint x="499.19426952141055" y="546.7561764705882" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-32" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-27" target="Uf8WLKuzS3drS_BCJ-BJ-29" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="547.0689546599496" y="566.0839272123158" as="sourcePoint" />
+            <mxPoint x="661.0107052896725" y="566.0839272123158" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-34" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;edgeStyle=orthogonalEdgeStyle;curved=1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-9" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="843.8920025188916" y="192.87113309466875" as="sourcePoint" />
+            <mxPoint x="957.8337531486145" y="192.87113309466875" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;verificationMethod&lt;/i&gt;" link="https://w3id.org/security/#verificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-38">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="1398.004710327456" y="89.75691176470589" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;authentication&lt;/i&gt;" link="https://w3id.org/security/#authentication" id="Uf8WLKuzS3drS_BCJ-BJ-39">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="1398.004710327456" y="137.60470588235296" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;assertionMethod&lt;/i&gt;" link="https://w3id.org/security/#assertionMethod" id="Uf8WLKuzS3drS_BCJ-BJ-40">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="1398.004710327456" y="185.45250000000004" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;capabilityDelegation&lt;/i&gt;" link="https://w3id.org/security/#capabilityDelegation" id="Uf8WLKuzS3drS_BCJ-BJ-41">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="1398.004710327456" y="233.30029411764707" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;capabilityInvocation&lt;/i&gt;" link="https://w3id.org/security/#capabilityInvocation" id="Uf8WLKuzS3drS_BCJ-BJ-42">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="1398.004710327456" y="281.14808823529415" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;keyAgreement&lt;/i&gt;" link="https://w3id.org/security/#keyAgreement" id="Uf8WLKuzS3drS_BCJ-BJ-43">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="1398.004710327456" y="328.99588235294124" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="multibase" link="https://w3id.org/security/#cryptosuiteString" id="aMvtbWUda6Bs1y7FLRK9-2">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="710.1783123425694" y="652.0213235294117" width="149.3690176322418" height="28.708676470588237" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="aMvtbWUda6Bs1y7FLRK9-4" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;edgeStyle=orthogonalEdgeStyle;curved=1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-11" target="aMvtbWUda6Bs1y7FLRK9-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="568" y="610.1971178589811" as="sourcePoint" />
+            <mxPoint x="687" y="610.1971178589811" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;Multikey&lt;/i&gt;" link="https://w3id.org/security/#Multikey" id="Uf8WLKuzS3drS_BCJ-BJ-58">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="919.5030667506297" y="450.00014705882353" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-72" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="851.9997607052896" y="548.5666029411765" width="343.7402392947103" height="32.5365" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;publicKeyMultibase&lt;/i&gt;" link="https://w3id.org/security/#publicKeyMultibase" id="Uf8WLKuzS3drS_BCJ-BJ-60">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-72" vertex="1">
+            <mxGeometry x="185.7537783375315" width="163.7314231738035" height="32.5365" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;secretKeyMultibase&lt;/i&gt;" link="https://w3id.org/security/#secretKeyMultibase" id="Uf8WLKuzS3drS_BCJ-BJ-61">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-72" vertex="1">
+            <mxGeometry x="-4.787468513853904" width="163.7314231738035" height="32.5365" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-73" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-61" target="Uf8WLKuzS3drS_BCJ-BJ-58" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1080.0309319899243" y="717.947794117647" as="sourcePoint" />
+            <mxPoint x="901.9371032745591" y="717.947794117647" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-74" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-60" target="Uf8WLKuzS3drS_BCJ-BJ-58" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1118.3306801007557" y="698.8086764705882" as="sourcePoint" />
+            <mxPoint x="940.2368513853904" y="698.8086764705882" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;JsonWebKey&lt;/i&gt;" link="https://w3id.org/security/#JsonWebKey" id="Uf8WLKuzS3drS_BCJ-BJ-57">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="1306.248016372796" y="450.00014705882353" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="rdf:JSON" id="Uf8WLKuzS3drS_BCJ-BJ-64">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="1335.93032115869" y="641.3913235294118" width="149.3690176322418" height="28.70867647058824" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-65" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="1232.9997481108312" y="548.5666029411765" width="355.2301637279597" height="32.536500000000004" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;secretKeyJwk&lt;/i&gt;" link="https://w3id.org/security/#secretKeyJwk" id="Uf8WLKuzS3drS_BCJ-BJ-62">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-65" vertex="1">
+            <mxGeometry width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;publicKeyJwk&lt;/i&gt;" link="https://w3id.org/security/#publicKeyJwk" id="Uf8WLKuzS3drS_BCJ-BJ-63">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-65" vertex="1">
+            <mxGeometry x="191.49874055415614" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-66" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-62" target="Uf8WLKuzS3drS_BCJ-BJ-57" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1325.8229534005038" y="727.5173529411766" as="sourcePoint" />
+            <mxPoint x="1147.7291246851385" y="727.5173529411766" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-67" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-63" target="Uf8WLKuzS3drS_BCJ-BJ-57" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1421.5723236775818" y="746.6564705882354" as="sourcePoint" />
+            <mxPoint x="1243.4784949622167" y="746.6564705882354" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-68" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-62" target="Uf8WLKuzS3drS_BCJ-BJ-64" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1243.4784949622167" y="746.8451036829041" as="sourcePoint" />
+            <mxPoint x="1357.4202455919394" y="746.8451036829041" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-69" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-63" target="Uf8WLKuzS3drS_BCJ-BJ-64" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1262.6283690176322" y="727.7059860358453" as="sourcePoint" />
+            <mxPoint x="1376.570119647355" y="727.7059860358453" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="nVRavBy3A-u7qQ1nN919-1" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-61" target="aMvtbWUda6Bs1y7FLRK9-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="808" y="470.1971178589811" as="sourcePoint" />
+            <mxPoint x="927" y="470.1971178589811" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="918" y="640" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="nVRavBy3A-u7qQ1nN919-3" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-60" target="aMvtbWUda6Bs1y7FLRK9-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="958" y="660.1971178589811" as="sourcePoint" />
+            <mxPoint x="1077" y="660.1971178589811" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1048" y="650" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;digestMultibase&lt;/i&gt;" link="https://w3.org/2018/credentials/#digestMultibase" id="0YF8A2KC1bUMDjYDby_S-1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="546.4489294710328" y="559.1980882352941" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="0YF8A2KC1bUMDjYDby_S-2" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;edgeStyle=orthogonalEdgeStyle;curved=1;" parent="1" source="0YF8A2KC1bUMDjYDby_S-1" target="aMvtbWUda6Bs1y7FLRK9-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="468" y="507.52" as="sourcePoint" />
+            <mxPoint x="534" y="720.52" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0YF8A2KC1bUMDjYDby_S-3" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-12" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="915.74" y="281.15" as="sourcePoint" />
+            <mxPoint x="1018.74" y="15.150000000000006" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1098" y="160" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/vocab/security/vocabulary.svg
+++ b/vocab/security/vocabulary.svg
@@ -1,12 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1633 879">
-    <rect width="1330" height="54.5" x="140" y="803.5" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="none"/>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m1374 830.25 63.26.19" pointer-events="none"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1444.76 830.46-10.01 4.97 2.51-4.99-2.48-5.01Z" pointer-events="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1623 879">
+    <rect width="1330" height="54.5" x="140" y="803.5" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m1374 830.25 63.26.19" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1444.76 830.46-10.01 4.97 2.51-4.99-2.48-5.01Z" pointer-events="all"/>
+    <rect width="70" height="40" x="1290" y="804.75" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:68px;height:1px;padding-top:812px;margin-left:1291px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
                             Graph containment
                         </span>
@@ -16,12 +17,13 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="1325" y="828" font-family="Helvetica" font-size="16" text-anchor="middle">Graph con...</text>
     </switch>
-    <ellipse cx="261.5" cy="831.14" fill="#d5e8d4" stroke="#82b366" stroke-width="2" pointer-events="none" rx="50" ry="14.002"/>
+    <ellipse cx="261.5" cy="831.14" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
+    <rect width="50" height="30" x="151.5" y="812.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:177px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Class
                     </div>
                 </div>
@@ -29,12 +31,13 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="177" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
     </switch>
-    <rect width="80" height="23.69" x="422" y="817.14" fill="#fff2cc" stroke="#300" stroke-width="2" pointer-events="none" rx="3.55" ry="3.55"/>
+    <rect width="80" height="23.69" x="422" y="817.14" fill="none" stroke="#300" stroke-width="2" pointer-events="all" rx="3.55" ry="3.55"/>
+    <rect width="70" height="30" x="339" y="812.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:374px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Property
                     </div>
                 </div>
@@ -42,13 +45,14 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="374" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m810 830.13 71.76.56" pointer-events="none"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m887.76 830.73-8.03 3.94 2.03-3.98-1.96-4.02Z" pointer-events="none"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m810 830.13 71.76.56" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m887.76 830.73-8.03 3.94 2.03-3.98-1.96-4.02Z" pointer-events="all"/>
+    <rect width="80" height="30" x="718" y="812.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:758px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Superclass
                     </div>
                 </div>
@@ -56,29 +60,29 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="758" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Superclass</text>
     </switch>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1007 830.75 56 .05 14.26-.03" pointer-events="none"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1084.76 830.75-9.99 5.03 2.49-5.01-2.51-4.99Z" pointer-events="none"/>
+    <path fill="none" stroke="#f33" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1007 830.75 56 .05 15.76-.03" pointer-events="stroke"/>
+    <path fill="#f33" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m1084.76 830.75-7.99 4.02 1.99-4-2-4Z" pointer-events="all"/>
+    <rect width="60" height="30" x="933" y="812.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:963px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Domain
-                        <br/>
-                        of
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="963" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Domain...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="963" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Domain</text>
     </switch>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1180 830.75h71.76" pointer-events="none"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1257.76 830.75-8 4 2-4-2-4Z" pointer-events="none"/>
+    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1180 830.75h71.76" pointer-events="stroke"/>
+    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1257.76 830.75-8 4 2-4-2-4Z" pointer-events="all"/>
+    <rect width="60" height="30" x="1113" y="812.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:1143px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Range
                     </div>
                 </div>
@@ -86,12 +90,13 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="1143" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
     </switch>
-    <path fill="#dae8fc" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M629 822.25h48.4l20 8.5-20 8.5H629l-20-8.5Z" pointer-events="none"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M629 822.25h48.4l20 8.5-20 8.5H629l-20-8.5Z" pointer-events="all"/>
+    <rect width="90" height="40" x="534" y="810.75" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:88px;height:1px;padding-top:818px;margin-left:536px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:center;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
                             Datatype
                         </span>
@@ -102,16 +107,14 @@
         <text xmlns="http://www.w3.org/2000/svg" x="536" y="834" font-family="Helvetica" font-size="16">Datatype</text>
     </switch>
     <a xlink:href="https://w3id.org/security/#VerificationMethod">
-        <ellipse cx="1222.03" cy="44.45" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="1222.03" cy="44.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:44px;margin-left:1119px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#f33">
-                                    VerificationMethod
-                                </font>
+                                VerificationMethod
                             </i>
                         </div>
                     </div>
@@ -121,95 +124,87 @@
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#controller">
-        <rect width="163.73" height="32.54" x="851" y="293.23" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="881" y="290" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:309px;margin-left:852px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:306px;margin-left:882px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    controller
-                                </font>
+                                controller
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="933" y="314" font-family="Helvetica" font-size="16" text-anchor="middle">controller</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="963" y="311" font-family="Helvetica" font-size="16" text-anchor="middle">controller</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#revoked">
-        <rect width="163.73" height="32.54" x="851" y="345" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="881" y="338.99" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:361px;margin-left:852px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:355px;margin-left:882px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    revoked
-                                </font>
+                                revoked
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="933" y="366" font-family="Helvetica" font-size="16" text-anchor="middle">revoked</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="963" y="360" font-family="Helvetica" font-size="16" text-anchor="middle">revoked</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 117.27q-60-16.27-106.25-50.69"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1298.74 62.11 11 1.95-4.99 2.52-.98 5.51Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 165.11q-70-44.11-108.31-96.48"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1298.26 62.58 9.94 5.11-5.51.94-2.56 4.97Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 212.96Q1341 141 1301.63 69.31"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1298.02 62.73 9.19 6.36-5.58.22-3.18 4.59Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 260.81Q1331 151 1300.38 69.88"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.73 62.86 8.21 7.59-5.56-.57-3.8 4.1Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 308.66Q1321 181 1298.85 70.32"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.38 62.96 6.87 8.83-5.4-1.47-4.41 3.43Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 356.5q-110-155.5-113.78-286"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.01 63.01 5.28 9.85-5.07-2.36-4.92 2.65Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M1020.66 301.77Q1121 171 1147.13 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1016.1 307.72 2.12-10.98 2.44 5.03 5.49 1.06Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M1020.76 353.63Q1141 201 1147.13 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1016.12 359.52 2.26-10.95 2.38 5.06 5.47 1.13Z"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 97.03q-70-6.03-106.52-30.69" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1298.26 62.14 11.09 1.46-4.87 2.74-.73 5.54Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 144.87q-80-33.87-109.06-75.96" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.68 62.73 9.8 5.39-5.54.79-2.69 4.89Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 192.72Q1341 141 1301.14 69.4" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.5 62.85 9.23 6.3-5.59.25-3.15 4.62Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 240.57Q1331 161 1299.59 70.1" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.14 63.01 7.99 7.82-5.54-.73-3.91 3.99Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 288.42Q1321 191 1298.22 70.46" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1296.82 63.09 6.77 8.9-5.37-1.53-4.45 3.39Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1411 336.26Q1311 221 1297.29 70.59" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1296.61 63.12 5.89 9.51-5.21-2.04-4.75 2.94Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M1049.42 297.73Q1141 131 1147.66 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1045.81 304.31.43-11.18 3.18 4.6 5.59.22Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M1049.93 347.03Q1161 171 1147.66 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1045.93 353.37 1.11-11.12 2.89 4.78 5.56.55Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#Ed25519VerificationKey2020">
-        <ellipse cx="1231.51" cy="401.55" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="113.84" ry="23.445"/>
+        <ellipse cx="1226.51" cy="404.44" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="113.84" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:226px;height:1px;padding-top:402px;margin-left:1119px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:226px;height:1px;padding-top:404px;margin-left:1114px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#f33">
-                                    Ed25519VerificationKey2020
-                                </font>
+                                Ed25519VerificationKey2020
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1232" y="406" font-family="Helvetica" font-size="16" text-anchor="middle">Ed25519VerificationKey2020</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1227" y="409" font-family="Helvetica" font-size="16" text-anchor="middle">Ed25519VerificationKey2020</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1433.61 441Q1251 281 1223.35 77.54"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.34 70.11 6.3 9.23-5.29-1.8-4.62 3.15Z"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1231.51 378.11-9.18-300.49"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.1 70.13 5.31 9.84-5.08-2.35-4.92 2.65Z"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1047.87 443Q1211 281 1221.53 77.61"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1221.92 70.12 4.48 10.25-4.87-2.76-5.12 2.24Z"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1423.61 441Q1231 291 1222.43 77.62" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.12 70.13 5.4 9.79-5.09-2.3-4.9 2.7Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1226.51 381-4.34-303.37" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.07 70.13 5.14 9.92-5.04-2.42-4.96 2.57Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1036.87 441Q1222 281 1222.03 77.63" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.03 70.13 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#Proof">
-        <ellipse cx="352.29" cy="44.45" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="352.29" cy="44.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:44px;margin-left:249px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#f33">
-                                    Proof
-                                </font>
+                                Proof
                             </i>
                         </div>
                     </div>
@@ -219,16 +214,14 @@
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#ProofGraph">
-        <ellipse cx="179.94" cy="178.42" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="179.94" cy="178.42" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:178px;margin-left:77px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#f33">
-                                    ProofGraph
-                                </font>
+                                ProofGraph
                             </i>
                         </div>
                     </div>
@@ -237,19 +230,17 @@
             <text xmlns="http://www.w3.org/2000/svg" x="180" y="183" font-family="Helvetica" font-size="16" text-anchor="middle">ProofGraph</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m179.94 154.97 90.45-87.43"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m275.78 62.33-3.72 10.54-1.67-5.33-5.28-1.86Z"/>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m179.94 154.97 90.96-87.33" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m276.31 62.44-3.75 10.53-1.66-5.33-5.27-1.88Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#proof">
-        <rect width="163.73" height="32.54" x="98.56" y="308.09" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="98.56" y="308.09" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:324px;margin-left:100px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    proof
-                                </font>
+                                proof
                             </i>
                         </div>
                     </div>
@@ -258,189 +249,171 @@
             <text xmlns="http://www.w3.org/2000/svg" x="180" y="329" font-family="Helvetica" font-size="16" text-anchor="middle">proof</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m180.42 308.09-.43-96.49"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m179.95 204.1 5.05 9.98-5.01-2.48-4.99 2.52Z"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m180.42 308.09-.43-96.49" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m179.95 204.1 5.05 9.98-5.01-2.48-4.99 2.52Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#domain">
-        <rect width="163.73" height="32.54" x="563.9" y="161" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="134" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:177px;margin-left:565px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:150px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    domain
-                                </font>
+                                domain
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="646" y="182" font-family="Helvetica" font-size="16" text-anchor="middle">domain</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="155" font-family="Helvetica" font-size="16" text-anchor="middle">domain</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#challenge">
-        <rect width="163.73" height="32.54" x="563.9" y="260" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="239" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:276px;margin-left:565px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:255px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    challenge
-                                </font>
+                                challenge
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="646" y="281" font-family="Helvetica" font-size="16" text-anchor="middle">challenge</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="260" font-family="Helvetica" font-size="16" text-anchor="middle">challenge</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#previousProof">
-        <rect width="163.73" height="32.54" x="563.9" y="112.99" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="87.89" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:129px;margin-left:565px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:104px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    previousProof
-                                </font>
+                                previousProof
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="646" y="134" font-family="Helvetica" font-size="16" text-anchor="middle">previousProof</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="109" font-family="Helvetica" font-size="16" text-anchor="middle">previousProof</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#proofPurpose">
-        <rect width="163.73" height="32.54" x="563.9" y="314.55" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="290.15" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:331px;margin-left:565px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:306px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    proofPurpose
-                                </font>
+                                proofPurpose
                                 <br/>
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="646" y="336" font-family="Helvetica" font-size="16" text-anchor="middle">proofPurpose
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="311" font-family="Helvetica" font-size="16" text-anchor="middle">proofPurpose
 </text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#proofValue">
-        <rect width="163.73" height="32.54" x="563.9" y="464" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="431.3" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:480px;margin-left:565px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:448px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    proofValue
-                                </font>
+                                proofValue
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="646" y="485" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="452" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#expires">
-        <rect width="163.73" height="32.54" x="851.01" y="235" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="881" y="238" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:251px;margin-left:852px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:254px;margin-left:882px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    expires
-                                </font>
+                                expires
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="933" y="256" font-family="Helvetica" font-size="16" text-anchor="middle">expires</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="963" y="259" font-family="Helvetica" font-size="16" text-anchor="middle">expires</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#nonce">
-        <rect width="163.73" height="32.54" x="563.9" y="368" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="338" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:384px;margin-left:565px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:354px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    nonce
-                                </font>
+                                nonce
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="646" y="389" font-family="Helvetica" font-size="16" text-anchor="middle">nonce</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="359" font-family="Helvetica" font-size="16" text-anchor="middle">nonce</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#created">
-        <rect width="163.73" height="32.54" x="563.9" y="416" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="385" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:432px;margin-left:565px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:401px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    created
-                                </font>
+                                created
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="646" y="437" font-family="Helvetica" font-size="16" text-anchor="middle">created</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="406" font-family="Helvetica" font-size="16" text-anchor="middle">created</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M555.4 172.52Q481 131 427.2 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m561.95 176.18-11.17-.51 4.62-3.15.25-5.58Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M558.53 268.15Q481 151 427.2 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m562.66 274.4-9.68-5.58 5.55-.67 2.79-4.85Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M554.55 126.54Q501 111 427.2 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m561.75 128.63-11 2.02 3.8-4.11-1.01-5.49Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M558.88 322.48Q481 193 427.2 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m562.75 328.9-9.44-5.99 5.57-.43 3-4.72Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M558.66 472.06Q411 241 427.2 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m562.69 478.38-9.59-5.73 5.56-.59 2.86-4.8Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M841.29 251.89Q541 271 427.2 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m848.78 251.41-9.66 5.63 2.17-5.15-2.81-4.83Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M558.04 376.49Q471 261 427.2 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m562.55 382.48-10.01-4.97 5.5-1.02 2.49-5Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557.82 424.66Q451 291 427.2 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m562.5 430.52-10.15-4.69 5.47-1.17 2.35-5.07Z"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M559.67 145.86Q491 111 426.67 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m566.36 149.26-11.18-.07 4.49-3.33.03-5.59Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M562.89 247.21Q491 141 426.67 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m567.1 253.42-9.75-5.48 5.54-.73 2.74-4.88Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M558.97 101.55Q521 91 426.67 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m566.19 103.56-10.97 2.14 3.75-4.15-1.07-5.48Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M563.68 297.88Q506.45 193.25 426.67 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m567.28 304.46-9.19-6.38 5.59-.2 3.18-4.6Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M562.51 439.78Q421 251 426.67 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m567.01 445.78-10-5.01 5.5-.99 2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M871.31 253.29Q551 221 426.98 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m878.77 254.04-10.45 3.98 2.99-4.73-1.98-5.22Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M561 347.88Q461 261 426.67 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m566.66 352.8-10.83-2.78 5.17-2.14 1.39-5.41Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M561.55 394.3Q451 281 426.67 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="M566.79 399.67 556.23 396l5.32-1.7 1.83-5.28Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#DataIntegrityProof">
-        <ellipse cx="352.29" cy="475.08" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="352.29" cy="475.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:475px;margin-left:249px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#f33">
-                                    DataIntegrityProof
-                                </font>
+                                DataIntegrityProof
                             </i>
                         </div>
                     </div>
@@ -450,16 +423,14 @@
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#Ed25519Signature2020">
-        <ellipse cx="125.37" cy="475.08" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="125.37" cy="475.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:475px;margin-left:22px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#f33">
-                                    Ed25519Signature2020
-                                </font>
+                                Ed25519Signature2020
                             </i>
                         </div>
                     </div>
@@ -468,21 +439,19 @@
             <text xmlns="http://www.w3.org/2000/svg" x="125" y="480" font-family="Helvetica" font-size="16" text-anchor="middle">Ed25519Signature2020</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M352.29 451.63v-374"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m352.29 70.13 5 10-5-2.5-5 2.5Z"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M194.25 457.35Q349.42 317.66 352.18 77.63"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m352.27 70.13 4.88 10.05-4.97-2.55-5.03 2.44Z"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M352.29 451.63v-374" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m352.29 70.13 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M194.25 457.35Q349.42 317.66 352.18 77.63" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m352.27 70.13 4.88 10.05-4.97-2.55-5.03 2.44Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#cryptosuite">
-        <rect width="163.73" height="32.54" x="270.91" y="550.2" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="270.91" y="550.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:566px;margin-left:272px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    cryptosuite
-                                </font>
+                                cryptosuite
                             </i>
                         </div>
                     </div>
@@ -492,15 +461,13 @@
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#cryptosuiteString">
-        <path fill="#dae8fc" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M297.61 643.02h109.37l20 14.36-20 14.35H297.61l-20-14.35Z" pointer-events="all"/>
+        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M297.61 643.02h109.37l20 14.36-20 14.35H297.61l-20-14.35Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:657px;margin-left:279px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font color="#bd0000">
-                                cryptosuiteString
-                            </font>
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            cryptosuiteString
                         </div>
                     </div>
                 </div>
@@ -508,136 +475,122 @@
             <text xmlns="http://www.w3.org/2000/svg" x="352" y="662" font-family="Helvetica" font-size="16" text-anchor="middle">cryptosuiteString</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m352.68 540.46-.39-41.94"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m352.75 547.96-5.09-9.95 5.02 2.45 4.98-2.55Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m352.77 582.73-.4 50.56"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m352.31 640.79-4.92-10.04 4.98 2.54 5.02-2.46Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M727.63 129.26q33.37.07 33.37-42.39 0-42.47-294.6-42.43"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m458.9 44.45 9.99-5.01-2.49 5 2.5 5Z"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m352.68 540.46-.39-41.94" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m352.75 547.96-5.09-9.95 5.02 2.45 4.98-2.55Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m352.77 582.73-.4 50.56" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m352.31 640.79-4.92-10.04 4.98 2.54 5.02-2.46Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M732.08 104.16q9.92.04 9.92-29.86T466.4 44.44" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m458.9 44.45 9.99-5.01-2.49 5 2.5 5Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#verificationMethod">
-        <rect width="163.73" height="32.54" x="1411" y="101" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="1411" y="80.76" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:117px;margin-left:1412px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:97px;margin-left:1412px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    verificationMethod
-                                </font>
+                                verificationMethod
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="122" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="102" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#authentication">
-        <rect width="163.73" height="32.54" x="1411" y="148.84" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="1411" y="128.6" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:165px;margin-left:1412px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:145px;margin-left:1412px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    authentication
-                                </font>
+                                authentication
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="170" font-family="Helvetica" font-size="16" text-anchor="middle">authentication</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="150" font-family="Helvetica" font-size="16" text-anchor="middle">authentication</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#assertionMethod">
-        <rect width="163.73" height="32.54" x="1411" y="196.69" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="1411" y="176.45" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:213px;margin-left:1412px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:193px;margin-left:1412px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    assertionMethod
-                                </font>
+                                assertionMethod
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="218" font-family="Helvetica" font-size="16" text-anchor="middle">assertionMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="198" font-family="Helvetica" font-size="16" text-anchor="middle">assertionMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#capabilityDelegation">
-        <rect width="163.73" height="32.54" x="1411" y="244.54" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="1411" y="224.3" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:261px;margin-left:1412px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:241px;margin-left:1412px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    capabilityDelegation
-                                </font>
+                                capabilityDelegation
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="266" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityDelegation</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="245" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityDelegation</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#capabilityInvocation">
-        <rect width="163.73" height="32.54" x="1411" y="292.39" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="1411" y="272.15" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:309px;margin-left:1412px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:288px;margin-left:1412px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    capabilityInvocation
-                                </font>
+                                capabilityInvocation
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="313" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityInvocation</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="293" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityInvocation</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#keyAgreement">
-        <rect width="163.73" height="32.54" x="1411" y="340.24" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="1411" y="320" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:357px;margin-left:1412px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:336px;margin-left:1412px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    keyAgreement
-                                </font>
+                                keyAgreement
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="361" font-family="Helvetica" font-size="16" text-anchor="middle">keyAgreement</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1493" y="341" font-family="Helvetica" font-size="16" text-anchor="middle">keyAgreement</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#cryptosuiteString">
-        <path fill="#dae8fc" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M743.18 643.02h109.37l20 14.36-20 14.35H743.18l-20-14.35Z" pointer-events="all"/>
+        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M743.18 643.02h109.37l20 14.36-20 14.35H743.18l-20-14.35Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:657px;margin-left:724px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font color="#bd0000">
-                                multibase
-                            </font>
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            multibase
                         </div>
                     </div>
                 </div>
@@ -645,175 +598,160 @@
             <text xmlns="http://www.w3.org/2000/svg" x="798" y="662" font-family="Helvetica" font-size="16" text-anchor="middle">multibase</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M727.63 480.27q70.3 0 70.24 153.02"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m797.86 640.79-4.99-10.01 5 2.51 5-2.5Z"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M732.08 447.57q65.82.03 65.78 185.72" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m797.86 640.79-4.99-10.01 4.99 2.51 5.01-2.5Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#Multikey">
-        <ellipse cx="1047.87" cy="466.45" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="1036.87" cy="464.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:466px;margin-left:945px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:464px;margin-left:934px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#f33">
-                                    Multikey
-                                </font>
+                                Multikey
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1048" y="471" font-family="Helvetica" font-size="16" text-anchor="middle">Multikey</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1037" y="469" font-family="Helvetica" font-size="16" text-anchor="middle">Multikey</text>
         </switch>
     </a>
-    <rect width="343.74" height="32.54" x="891" y="539.57" fill="none"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m961.63 536.91 86.24-47.02"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m955.04 540.5 6.39-9.18.2 5.59 4.58 3.19Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1135.05 536.94-87.18-47.05"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1141.65 540.5-11.17-.34 4.57-3.22.18-5.58Z"/>
+    <rect width="343.74" height="32.54" x="865" y="539.57" fill="none"/>
+    <a xlink:href="https://w3id.org/security/#publicKeyMultibase">
+        <rect width="163.73" height="32.54" x="1050.75" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:1052px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                publicKeyMultibase
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1133" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyMultibase</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3id.org/security/#secretKeyMultibase">
+        <rect width="163.73" height="32.54" x="860.21" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:861px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                secretKeyMultibase
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="942" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyMultibase</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m950.63 534.91 86.24-47.02" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m944.04 538.5 6.39-9.18.2 5.59 4.58 3.19Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1124.05 534.94-87.18-47.05" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1130.65 538.5-11.17-.34 4.57-3.22.18-5.58Z" pointer-events="all"/>
     <a xlink:href="https://w3id.org/security/#JsonWebKey">
-        <ellipse cx="1433.61" cy="464.45" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="1423.61" cy="464.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:464px;margin-left:1330px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:464px;margin-left:1320px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#f33">
-                                    JsonWebKey
-                                </font>
+                                JsonWebKey
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1434" y="469" font-family="Helvetica" font-size="16" text-anchor="middle">JsonWebKey</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1424" y="469" font-family="Helvetica" font-size="16" text-anchor="middle">JsonWebKey</text>
         </switch>
     </a>
-    <path fill="#dae8fc" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1378.93 642.39h109.37l20 14.36-20 14.35h-109.37l-20-14.35Z"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1368.93 632.39h109.37l20 14.36-20 14.35h-109.37l-20-14.35Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:657px;margin-left:1360px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:647px;margin-left:1350px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                        <font color="#bd0000">
-                            rdf:JSON
-                        </font>
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        rdf:JSON
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="1434" y="662" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="1424" y="652" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
     </switch>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1346.43 534.94 87.18-47.05"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1339.83 538.5 6.43-9.14.17 5.58 4.58 3.22Z"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1520.8 534.94-87.19-47.05"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1527.4 538.5-11.18-.34 4.58-3.22.17-5.58Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1337.87 572.1 87.9 64.53"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1431.81 641.07-11.02-1.89 4.98-2.55.94-5.51Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1529.36 572.1-87.9 64.53"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1435.42 641.07 5.1-9.95.94 5.51 4.98 2.55Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M953.08 574.1Q931 631 881.42 653.37"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m874.59 656.46 7.05-8.67-.22 5.58 4.34 3.53Z"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1143.62 574.1Q1061 641 882.25 656.53"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m874.77 657.18 9.53-5.84-2.05 5.19 2.92 4.77Z"/>
-    <a xlink:href="https://w3id.org/security/#publicKeyMultibase">
-        <rect width="163.73" height="32.54" x="1061.75" y="541.57" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:558px;margin-left:1063px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <i>
-                                <font color="#bd0000">
-                                    publicKeyMultibase
-                                </font>
-                            </i>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1144" y="563" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyMultibase</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3id.org/security/#secretKeyMultibase">
-        <rect width="163.73" height="32.54" x="871.21" y="541.57" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:558px;margin-left:872px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <i>
-                                <font color="#bd0000">
-                                    secretKeyMultibase
-                                </font>
-                            </i>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="953" y="563" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyMultibase</text>
-        </switch>
-    </a>
+    <rect width="355.23" height="32.54" x="1246" y="539.57" fill="none"/>
     <a xlink:href="https://w3id.org/security/#secretKeyJwk">
-        <rect width="163.73" height="32.54" x="1256" y="539.57" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="1246" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:1257px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:1247px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    secretKeyJwk
-                                </font>
+                                secretKeyJwk
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1338" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyJwk</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1328" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyJwk</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security/#publicKeyJwk">
-        <rect width="163.73" height="32.54" x="1447.5" y="539.57" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="1437.5" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:1448px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:1438px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    publicKeyJwk
-                                </font>
+                                publicKeyJwk
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1529" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyJwk</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1519" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyJwk</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M1021.14 243.93Q1111 141 1147.13 60.77"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1016.21 249.58 2.81-10.82 2.12 5.17 5.41 1.41Z"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1336.43 534.94 87.18-47.05" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1329.83 538.5 6.43-9.14.17 5.58 4.58 3.22Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1510.8 534.94-87.19-47.05" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1517.4 538.5-11.18-.34 4.58-3.22.17-5.58Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1327.87 572.1 87.51 55.1" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1421.72 631.2-11.12-1.1 4.78-2.9.54-5.56Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1519.36 572.1-87.51 55.1" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1425.51 631.2 5.8-9.56.54 5.56 4.78 2.9Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M942.08 572.1Q931 631 881.42 653.37" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m874.59 656.46 7.05-8.67-.22 5.58 4.34 3.53Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1132.62 572.1Q1061 641 882.25 656.53" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m874.77 657.18 9.53-5.84-2.05 5.19 2.92 4.77Z" pointer-events="all"/>
     <a xlink:href="https://w3.org/2018/credentials/#digestMultibase">
-        <rect width="163.73" height="32.54" x="563.9" y="550.2" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="559.45" y="550.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:566px;margin-left:565px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:566px;margin-left:560px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
-                                    digestMultibase
-                                </font>
+                                digestMultibase
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="646" y="571" font-family="Helvetica" font-size="16" text-anchor="middle">digestMultibase</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="641" y="571" font-family="Helvetica" font-size="16" text-anchor="middle">digestMultibase</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M645.76 582.73q.04 74.74 67.68 74.66"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m720.94 657.38-9.99 5.01 2.49-5-2.5-5Z"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M641.31 582.73q-.01 74.67 72.13 74.65" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m720.94 657.38-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M1049.99 246.07Q1111 151 1147.66 60.89" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1045.94 252.39 1.19-11.12 2.86 4.8 5.56.6Z" pointer-events="all"/>
 </svg>


### PR DESCRIPTION
This changes the vocab diagram to be dark-mode safe, by essentially using only a few colors for the connector lines. The content of the diagram has not changed.

Furthermore, just as what was done in https://github.com/w3c/vc-data-model/pull/1296 for the VCDM spec, the original `drawio` source of the diagram has been added to the repository to make make updates and changes better tracable. The README file has been updated accordingly.