### PR TITLE
Updated the URL-s in the vocabulary

### DIFF
--- a/vocab/security/.$vocabulary.drawio.bkp
+++ b/vocab/security/.$vocabulary.drawio.bkp
@@ -1,4 +1,4 @@
-<mxfile host="Electron" modified="2023-10-18T06:59:33.055Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.0.2 Chrome/114.0.5735.289 Electron/25.8.4 Safari/537.36" etag="IhpbdUE1Z5rGB04jLSLF" version="22.0.2" type="device">
+<mxfile host="Electron" modified="2023-10-18T06:59:02.668Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.0.2 Chrome/114.0.5735.289 Electron/25.8.4 Safari/537.36" etag="Wiul4hF7IiNVehw98v2E" version="22.0.2" type="device">
   <diagram name="Page-1" id="hQ0IBVJ5jpEcegRt-_B3">
     <mxGraphModel dx="1710" dy="1142" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
       <root>
@@ -262,7 +262,7 @@
             <mxGeometry x="555.3489294710328" y="440.29808823529413" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;expiration&lt;/i&gt;" link="https://w3id.org/security#expiration" id="Uf8WLKuzS3drS_BCJ-BJ-12">
+        <UserObject label="&lt;i&gt;expiration&lt;/i&gt;" link="https://w3id.org/security#expires" id="Uf8WLKuzS3drS_BCJ-BJ-12">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="867.9989294710327" y="247" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>

--- a/vocab/security/template.html
+++ b/vocab/security/template.html
@@ -14,7 +14,7 @@
         const retval = content
           .replace('<svg', '<svg aria-details="#vocabulary-diagram-alt" ')
           .replace(/xlink:href/g, 'href')
-          .replace(/href="https:\/\/w3id.org\/security\/#/g, 'href="#');
+          .replace(/href="https:\/\/w3id.org\/security#/g, 'href="#');
         return retval;
       }
     </script>

--- a/vocab/security/vocabulary.drawio
+++ b/vocab/security/vocabulary.drawio
@@ -94,17 +94,17 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-112" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" parent="Uf8WLKuzS3drS_BCJ-BJ-113" vertex="1">
           <mxGeometry width="90" height="40" as="geometry" />
         </mxCell>
-        <UserObject label="&lt;i&gt;VerificationMethod&lt;/i&gt;" link="https://w3id.org/security/#VerificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-37">
+        <UserObject label="&lt;i&gt;VerificationMethod&lt;/i&gt;" link="https://w3id.org/security#VerificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-37">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="1104.668136020151" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;controller&lt;/i&gt;" link="https://w3id.org/security/#controller" id="Uf8WLKuzS3drS_BCJ-BJ-44">
+        <UserObject label="&lt;i&gt;controller&lt;/i&gt;" link="https://w3id.org/security#controller" id="Uf8WLKuzS3drS_BCJ-BJ-44">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="868.003765743073" y="298.9969117647059" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;revoked&lt;/i&gt;" link="https://w3id.org/security/#revoked" id="Uf8WLKuzS3drS_BCJ-BJ-45">
+        <UserObject label="&lt;i&gt;revoked&lt;/i&gt;" link="https://w3id.org/security#revoked" id="Uf8WLKuzS3drS_BCJ-BJ-45">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="868.003765743073" y="347.99470588235295" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
@@ -181,7 +181,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;Ed25519VerificationKey2020&lt;/i&gt;" link="https://w3id.org/security/#Ed25519VerificationKey2020" id="Uf8WLKuzS3drS_BCJ-BJ-56">
+        <UserObject label="&lt;i&gt;Ed25519VerificationKey2020&lt;/i&gt;" link="https://w3id.org/security#Ed25519VerificationKey2020" id="Uf8WLKuzS3drS_BCJ-BJ-56">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="1099.67" y="390" width="227.68" height="46.89" as="geometry" />
           </mxCell>
@@ -210,12 +210,12 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;Proof&lt;/i&gt;" link="https://w3id.org/security/#Proof" id="Uf8WLKuzS3drS_BCJ-BJ-1">
+        <UserObject label="&lt;i&gt;Proof&lt;/i&gt;" link="https://w3id.org/security#Proof" id="Uf8WLKuzS3drS_BCJ-BJ-1">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;pointer-events=&quot;all&quot;" parent="1" vertex="1">
             <mxGeometry x="234.92600755667502" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;ProofGraph&lt;/i&gt;" link="https://w3id.org/security/#ProofGraph" id="Uf8WLKuzS3drS_BCJ-BJ-2">
+        <UserObject label="&lt;i&gt;ProofGraph&lt;/i&gt;" link="https://w3id.org/security#ProofGraph" id="Uf8WLKuzS3drS_BCJ-BJ-2">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="62.57714105793451" y="163.97382352941176" width="208.7336272040302" height="46.89083823529412" as="geometry" />
           </mxCell>
@@ -226,7 +226,7 @@
             <mxPoint x="464.72449622166243" y="125.69558823529412" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;proof&lt;/i&gt;" link="https://w3id.org/security/#proof" id="Uf8WLKuzS3drS_BCJ-BJ-5">
+        <UserObject label="&lt;i&gt;proof&lt;/i&gt;" link="https://w3id.org/security#proof" id="Uf8WLKuzS3drS_BCJ-BJ-5">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="85.55698992443325" y="317.08676470588233" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
@@ -237,42 +237,42 @@
             <mxPoint x="415.8923173803526" y="259.8580448593747" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;domain&lt;/i&gt;" link="https://w3id.org/security/#domain" id="Uf8WLKuzS3drS_BCJ-BJ-7">
+        <UserObject label="&lt;i&gt;domain&lt;/i&gt;" link="https://w3id.org/security#domain" id="Uf8WLKuzS3drS_BCJ-BJ-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="555.3489294710328" y="143" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;challenge&lt;/i&gt;" link="https://w3id.org/security/#challenge" id="Uf8WLKuzS3drS_BCJ-BJ-8">
+        <UserObject label="&lt;i&gt;challenge&lt;/i&gt;" link="https://w3id.org/security#challenge" id="Uf8WLKuzS3drS_BCJ-BJ-8">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="555.3489294710328" y="248" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;previousProof&lt;/i&gt;" link="https://w3id.org/security/#previousProof" id="Uf8WLKuzS3drS_BCJ-BJ-9">
+        <UserObject label="&lt;i&gt;previousProof&lt;/i&gt;" link="https://w3id.org/security#previousProof" id="Uf8WLKuzS3drS_BCJ-BJ-9">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="555.3489294710328" y="96.8925" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;proofPurpose&lt;br&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#proofPurpose" id="Uf8WLKuzS3drS_BCJ-BJ-10">
+        <UserObject label="&lt;i&gt;proofPurpose&lt;br&gt;&lt;/i&gt;" link="https://w3id.org/security#proofPurpose" id="Uf8WLKuzS3drS_BCJ-BJ-10">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="555.3489294710328" y="299.15" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;proofValue&lt;/i&gt;" link="https://w3.org/2018/credentials/#proofValue" id="Uf8WLKuzS3drS_BCJ-BJ-11">
+        <UserObject label="&lt;i&gt;proofValue&lt;/i&gt;" link="https://w3id.org/security#proofValue" id="Uf8WLKuzS3drS_BCJ-BJ-11">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="555.3489294710328" y="440.29808823529413" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;expires&lt;/i&gt;" link="https://w3.org/2018/credentials/#expires" id="Uf8WLKuzS3drS_BCJ-BJ-12">
+        <UserObject label="&lt;i&gt;expires&lt;/i&gt;" link="https://w3id.org/security#expires" id="Uf8WLKuzS3drS_BCJ-BJ-12">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="867.9989294710327" y="247" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;nonce&lt;/i&gt;" link="https://w3.org/2018/credentials/#nonce" id="Uf8WLKuzS3drS_BCJ-BJ-13">
+        <UserObject label="&lt;i&gt;nonce&lt;/i&gt;" link="https://w3id.org/security#nonce" id="Uf8WLKuzS3drS_BCJ-BJ-13">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="555.3489294710328" y="347" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;created&lt;/i&gt;" link="https://w3.org/2018/credentials/#created" id="Uf8WLKuzS3drS_BCJ-BJ-14">
+        <UserObject label="&lt;i&gt;created&lt;/i&gt;" link="https://w3id.org/security#created" id="Uf8WLKuzS3drS_BCJ-BJ-14">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="555.3489294710328" y="394" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
@@ -349,12 +349,12 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;DataIntegrityProof&lt;/i&gt;" link="https://w3id.org/security/#DataIntegrityProof" id="Uf8WLKuzS3drS_BCJ-BJ-23">
+        <UserObject label="&lt;i&gt;DataIntegrityProof&lt;/i&gt;" link="https://w3id.org/security#DataIntegrityProof" id="Uf8WLKuzS3drS_BCJ-BJ-23">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="234.92600755667502" y="460.6301470588235" width="208.7336272040302" height="46.89083823529412" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;Ed25519Signature2020&lt;/i&gt;" link="https://w3id.org/security/#Ed25519Signature2020" id="Uf8WLKuzS3drS_BCJ-BJ-24">
+        <UserObject label="&lt;i&gt;Ed25519Signature2020&lt;/i&gt;" link="https://w3id.org/security#Ed25519Signature2020" id="Uf8WLKuzS3drS_BCJ-BJ-24">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="8" y="460.6301470588235" width="208.7336272040302" height="46.89083823529412" as="geometry" />
           </mxCell>
@@ -374,12 +374,12 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;cryptosuite&lt;/i&gt;" link="https://w3id.org/security/#cryptosuite" id="Uf8WLKuzS3drS_BCJ-BJ-27">
+        <UserObject label="&lt;i&gt;cryptosuite&lt;/i&gt;" link="https://w3id.org/security#cryptosuite" id="Uf8WLKuzS3drS_BCJ-BJ-27">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="257.90585642317376" y="559.1966029411765" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="cryptosuiteString" link="https://w3id.org/security/#cryptosuiteString" id="Uf8WLKuzS3drS_BCJ-BJ-29">
+        <UserObject label="cryptosuiteString" link="https://w3id.org/security#cryptosuiteString" id="Uf8WLKuzS3drS_BCJ-BJ-29">
           <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="264.60831234256926" y="652.0213235294117" width="149.3690176322418" height="28.708676470588237" as="geometry" />
           </mxCell>
@@ -405,37 +405,37 @@
             <mxPoint x="957.8337531486145" y="192.87113309466875" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;verificationMethod&lt;/i&gt;" link="https://w3id.org/security/#verificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-38">
+        <UserObject label="&lt;i&gt;verificationMethod&lt;/i&gt;" link="https://w3id.org/security#verificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-38">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="1398.004710327456" y="89.75691176470589" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;authentication&lt;/i&gt;" link="https://w3id.org/security/#authentication" id="Uf8WLKuzS3drS_BCJ-BJ-39">
+        <UserObject label="&lt;i&gt;authentication&lt;/i&gt;" link="https://w3id.org/security#authentication" id="Uf8WLKuzS3drS_BCJ-BJ-39">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="1398.004710327456" y="137.60470588235296" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;assertionMethod&lt;/i&gt;" link="https://w3id.org/security/#assertionMethod" id="Uf8WLKuzS3drS_BCJ-BJ-40">
+        <UserObject label="&lt;i&gt;assertionMethod&lt;/i&gt;" link="https://w3id.org/security#assertionMethod" id="Uf8WLKuzS3drS_BCJ-BJ-40">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="1398.004710327456" y="185.45250000000004" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;capabilityDelegation&lt;/i&gt;" link="https://w3id.org/security/#capabilityDelegation" id="Uf8WLKuzS3drS_BCJ-BJ-41">
+        <UserObject label="&lt;i&gt;capabilityDelegation&lt;/i&gt;" link="https://w3id.org/security#capabilityDelegation" id="Uf8WLKuzS3drS_BCJ-BJ-41">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="1398.004710327456" y="233.30029411764707" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;capabilityInvocation&lt;/i&gt;" link="https://w3id.org/security/#capabilityInvocation" id="Uf8WLKuzS3drS_BCJ-BJ-42">
+        <UserObject label="&lt;i&gt;capabilityInvocation&lt;/i&gt;" link="https://w3id.org/security#capabilityInvocation" id="Uf8WLKuzS3drS_BCJ-BJ-42">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="1398.004710327456" y="281.14808823529415" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;keyAgreement&lt;/i&gt;" link="https://w3id.org/security/#keyAgreement" id="Uf8WLKuzS3drS_BCJ-BJ-43">
+        <UserObject label="&lt;i&gt;keyAgreement&lt;/i&gt;" link="https://w3id.org/security#keyAgreement" id="Uf8WLKuzS3drS_BCJ-BJ-43">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="1398.004710327456" y="328.99588235294124" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="multibase" link="https://w3id.org/security/#cryptosuiteString" id="aMvtbWUda6Bs1y7FLRK9-2">
+        <UserObject label="multibase" link="https://w3id.org/security#cryptosuiteString" id="aMvtbWUda6Bs1y7FLRK9-2">
           <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="710.1783123425694" y="652.0213235294117" width="149.3690176322418" height="28.708676470588237" as="geometry" />
           </mxCell>
@@ -446,7 +446,7 @@
             <mxPoint x="687" y="610.1971178589811" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;Multikey&lt;/i&gt;" link="https://w3id.org/security/#Multikey" id="Uf8WLKuzS3drS_BCJ-BJ-58">
+        <UserObject label="&lt;i&gt;Multikey&lt;/i&gt;" link="https://w3id.org/security#Multikey" id="Uf8WLKuzS3drS_BCJ-BJ-58">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="919.5030667506297" y="450.00014705882353" width="208.7336272040302" height="46.89083823529412" as="geometry" />
           </mxCell>
@@ -454,12 +454,12 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-72" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="851.9997607052896" y="548.5666029411765" width="343.7402392947103" height="32.5365" as="geometry" />
         </mxCell>
-        <UserObject label="&lt;i&gt;publicKeyMultibase&lt;/i&gt;" link="https://w3id.org/security/#publicKeyMultibase" id="Uf8WLKuzS3drS_BCJ-BJ-60">
+        <UserObject label="&lt;i&gt;publicKeyMultibase&lt;/i&gt;" link="https://w3id.org/security#publicKeyMultibase" id="Uf8WLKuzS3drS_BCJ-BJ-60">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-72" vertex="1">
             <mxGeometry x="185.7537783375315" width="163.7314231738035" height="32.5365" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;secretKeyMultibase&lt;/i&gt;" link="https://w3id.org/security/#secretKeyMultibase" id="Uf8WLKuzS3drS_BCJ-BJ-61">
+        <UserObject label="&lt;i&gt;secretKeyMultibase&lt;/i&gt;" link="https://w3id.org/security#secretKeyMultibase" id="Uf8WLKuzS3drS_BCJ-BJ-61">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-72" vertex="1">
             <mxGeometry x="-4.787468513853904" width="163.7314231738035" height="32.5365" as="geometry" />
           </mxCell>
@@ -476,7 +476,7 @@
             <mxPoint x="940.2368513853904" y="698.8086764705882" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;JsonWebKey&lt;/i&gt;" link="https://w3id.org/security/#JsonWebKey" id="Uf8WLKuzS3drS_BCJ-BJ-57">
+        <UserObject label="&lt;i&gt;JsonWebKey&lt;/i&gt;" link="https://w3id.org/security#JsonWebKey" id="Uf8WLKuzS3drS_BCJ-BJ-57">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="1306.248016372796" y="450.00014705882353" width="208.7336272040302" height="46.89083823529412" as="geometry" />
           </mxCell>
@@ -489,12 +489,12 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-65" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="1232.9997481108312" y="548.5666029411765" width="355.2301637279597" height="32.536500000000004" as="geometry" />
         </mxCell>
-        <UserObject label="&lt;i&gt;secretKeyJwk&lt;/i&gt;" link="https://w3id.org/security/#secretKeyJwk" id="Uf8WLKuzS3drS_BCJ-BJ-62">
+        <UserObject label="&lt;i&gt;secretKeyJwk&lt;/i&gt;" link="https://w3id.org/security#secretKeyJwk" id="Uf8WLKuzS3drS_BCJ-BJ-62">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-65" vertex="1">
             <mxGeometry width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;publicKeyJwk&lt;/i&gt;" link="https://w3id.org/security/#publicKeyJwk" id="Uf8WLKuzS3drS_BCJ-BJ-63">
+        <UserObject label="&lt;i&gt;publicKeyJwk&lt;/i&gt;" link="https://w3id.org/security#publicKeyJwk" id="Uf8WLKuzS3drS_BCJ-BJ-63">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-65" vertex="1">
             <mxGeometry x="191.49874055415614" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
@@ -541,7 +541,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;digestMultibase&lt;/i&gt;" link="https://w3.org/2018/credentials/#digestMultibase" id="0YF8A2KC1bUMDjYDby_S-1">
+        <UserObject label="&lt;i&gt;digestMultibase&lt;/i&gt;" link="https://w3id.org/security#digestMultibase" id="0YF8A2KC1bUMDjYDby_S-1">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="546.4489294710328" y="559.1980882352941" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>

--- a/vocab/security/vocabulary.svg
+++ b/vocab/security/vocabulary.svg
@@ -106,7 +106,7 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="536" y="834" font-family="Helvetica" font-size="16">Datatype</text>
     </switch>
-    <a xlink:href="https://w3id.org/security/#VerificationMethod">
+    <a xlink:href="https://w3id.org/security#VerificationMethod">
         <ellipse cx="1222.03" cy="44.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -123,7 +123,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1222" y="49" font-family="Helvetica" font-size="16" text-anchor="middle">VerificationMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#controller">
+    <a xlink:href="https://w3id.org/security#controller">
         <rect width="163.73" height="32.54" x="881" y="290" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -140,7 +140,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="963" y="311" font-family="Helvetica" font-size="16" text-anchor="middle">controller</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#revoked">
+    <a xlink:href="https://w3id.org/security#revoked">
         <rect width="163.73" height="32.54" x="881" y="338.99" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -173,7 +173,7 @@
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1045.81 304.31.43-11.18 3.18 4.6 5.59.22Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M1049.93 347.03Q1161 171 1147.66 60.89" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1045.93 353.37 1.11-11.12 2.89 4.78 5.56.55Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#Ed25519VerificationKey2020">
+    <a xlink:href="https://w3id.org/security#Ed25519VerificationKey2020">
         <ellipse cx="1226.51" cy="404.44" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="113.84" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -196,7 +196,7 @@
     <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.07 70.13 5.14 9.92-5.04-2.42-4.96 2.57Z" pointer-events="all"/>
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1036.87 441Q1222 281 1222.03 77.63" pointer-events="stroke"/>
     <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.03 70.13 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#Proof">
+    <a xlink:href="https://w3id.org/security#Proof">
         <ellipse cx="352.29" cy="44.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -213,7 +213,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="352" y="49" font-family="Helvetica" font-size="16" text-anchor="middle">Proof</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#ProofGraph">
+    <a xlink:href="https://w3id.org/security#ProofGraph">
         <ellipse cx="179.94" cy="178.42" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -232,7 +232,7 @@
     </a>
     <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m179.94 154.97 90.96-87.33" pointer-events="stroke"/>
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m276.31 62.44-3.75 10.53-1.66-5.33-5.27-1.88Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#proof">
+    <a xlink:href="https://w3id.org/security#proof">
         <rect width="163.73" height="32.54" x="98.56" y="308.09" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -251,7 +251,7 @@
     </a>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m180.42 308.09-.43-96.49" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m179.95 204.1 5.05 9.98-5.01-2.48-4.99 2.52Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#domain">
+    <a xlink:href="https://w3id.org/security#domain">
         <rect width="163.73" height="32.54" x="568.35" y="134" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -268,7 +268,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="650" y="155" font-family="Helvetica" font-size="16" text-anchor="middle">domain</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#challenge">
+    <a xlink:href="https://w3id.org/security#challenge">
         <rect width="163.73" height="32.54" x="568.35" y="239" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -285,7 +285,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="650" y="260" font-family="Helvetica" font-size="16" text-anchor="middle">challenge</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#previousProof">
+    <a xlink:href="https://w3id.org/security#previousProof">
         <rect width="163.73" height="32.54" x="568.35" y="87.89" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -302,7 +302,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="650" y="109" font-family="Helvetica" font-size="16" text-anchor="middle">previousProof</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#proofPurpose">
+    <a xlink:href="https://w3id.org/security#proofPurpose">
         <rect width="163.73" height="32.54" x="568.35" y="290.15" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -321,7 +321,7 @@
 </text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#proofValue">
+    <a xlink:href="https://w3id.org/security#proofValue">
         <rect width="163.73" height="32.54" x="568.35" y="431.3" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -338,7 +338,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="650" y="452" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#expires">
+    <a xlink:href="https://w3id.org/security#expires">
         <rect width="163.73" height="32.54" x="881" y="238" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -355,7 +355,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="963" y="259" font-family="Helvetica" font-size="16" text-anchor="middle">expires</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#nonce">
+    <a xlink:href="https://w3id.org/security#nonce">
         <rect width="163.73" height="32.54" x="568.35" y="338" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -372,7 +372,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="650" y="359" font-family="Helvetica" font-size="16" text-anchor="middle">nonce</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#created">
+    <a xlink:href="https://w3id.org/security#created">
         <rect width="163.73" height="32.54" x="568.35" y="385" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -405,7 +405,7 @@
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m566.66 352.8-10.83-2.78 5.17-2.14 1.39-5.41Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M561.55 394.3Q451 281 426.67 60.89" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="M566.79 399.67 556.23 396l5.32-1.7 1.83-5.28Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#DataIntegrityProof">
+    <a xlink:href="https://w3id.org/security#DataIntegrityProof">
         <ellipse cx="352.29" cy="475.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -422,7 +422,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="352" y="480" font-family="Helvetica" font-size="16" text-anchor="middle">DataIntegrityProof</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#Ed25519Signature2020">
+    <a xlink:href="https://w3id.org/security#Ed25519Signature2020">
         <ellipse cx="125.37" cy="475.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -443,7 +443,7 @@
     <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m352.29 70.13 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M194.25 457.35Q349.42 317.66 352.18 77.63" pointer-events="stroke"/>
     <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m352.27 70.13 4.88 10.05-4.97-2.55-5.03 2.44Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#cryptosuite">
+    <a xlink:href="https://w3id.org/security#cryptosuite">
         <rect width="163.73" height="32.54" x="270.91" y="550.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -460,7 +460,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="353" y="571" font-family="Helvetica" font-size="16" text-anchor="middle">cryptosuite</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#cryptosuiteString">
+    <a xlink:href="https://w3id.org/security#cryptosuiteString">
         <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M297.61 643.02h109.37l20 14.36-20 14.35H297.61l-20-14.35Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -481,7 +481,7 @@
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m352.31 640.79-4.92-10.04 4.98 2.54 5.02-2.46Z" pointer-events="all"/>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M732.08 104.16q9.92.04 9.92-29.86T466.4 44.44" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m458.9 44.45 9.99-5.01-2.49 5 2.5 5Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#verificationMethod">
+    <a xlink:href="https://w3id.org/security#verificationMethod">
         <rect width="163.73" height="32.54" x="1411" y="80.76" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -498,7 +498,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1493" y="102" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#authentication">
+    <a xlink:href="https://w3id.org/security#authentication">
         <rect width="163.73" height="32.54" x="1411" y="128.6" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -515,7 +515,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1493" y="150" font-family="Helvetica" font-size="16" text-anchor="middle">authentication</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#assertionMethod">
+    <a xlink:href="https://w3id.org/security#assertionMethod">
         <rect width="163.73" height="32.54" x="1411" y="176.45" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -532,7 +532,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1493" y="198" font-family="Helvetica" font-size="16" text-anchor="middle">assertionMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#capabilityDelegation">
+    <a xlink:href="https://w3id.org/security#capabilityDelegation">
         <rect width="163.73" height="32.54" x="1411" y="224.3" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -549,7 +549,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1493" y="245" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityDelegation</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#capabilityInvocation">
+    <a xlink:href="https://w3id.org/security#capabilityInvocation">
         <rect width="163.73" height="32.54" x="1411" y="272.15" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -566,7 +566,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1493" y="293" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityInvocation</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#keyAgreement">
+    <a xlink:href="https://w3id.org/security#keyAgreement">
         <rect width="163.73" height="32.54" x="1411" y="320" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -583,7 +583,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1493" y="341" font-family="Helvetica" font-size="16" text-anchor="middle">keyAgreement</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#cryptosuiteString">
+    <a xlink:href="https://w3id.org/security#cryptosuiteString">
         <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M743.18 643.02h109.37l20 14.36-20 14.35H743.18l-20-14.35Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -600,7 +600,7 @@
     </a>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M732.08 447.57q65.82.03 65.78 185.72" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m797.86 640.79-4.99-10.01 4.99 2.51 5.01-2.5Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#Multikey">
+    <a xlink:href="https://w3id.org/security#Multikey">
         <ellipse cx="1036.87" cy="464.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -618,7 +618,7 @@
         </switch>
     </a>
     <rect width="343.74" height="32.54" x="865" y="539.57" fill="none"/>
-    <a xlink:href="https://w3id.org/security/#publicKeyMultibase">
+    <a xlink:href="https://w3id.org/security#publicKeyMultibase">
         <rect width="163.73" height="32.54" x="1050.75" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -635,7 +635,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1133" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyMultibase</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#secretKeyMultibase">
+    <a xlink:href="https://w3id.org/security#secretKeyMultibase">
         <rect width="163.73" height="32.54" x="860.21" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -656,7 +656,7 @@
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m944.04 538.5 6.39-9.18.2 5.59 4.58 3.19Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1124.05 534.94-87.18-47.05" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1130.65 538.5-11.17-.34 4.57-3.22.18-5.58Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security/#JsonWebKey">
+    <a xlink:href="https://w3id.org/security#JsonWebKey">
         <ellipse cx="1423.61" cy="464.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -687,7 +687,7 @@
         <text xmlns="http://www.w3.org/2000/svg" x="1424" y="652" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
     </switch>
     <rect width="355.23" height="32.54" x="1246" y="539.57" fill="none"/>
-    <a xlink:href="https://w3id.org/security/#secretKeyJwk">
+    <a xlink:href="https://w3id.org/security#secretKeyJwk">
         <rect width="163.73" height="32.54" x="1246" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -704,7 +704,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1328" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyJwk</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#publicKeyJwk">
+    <a xlink:href="https://w3id.org/security#publicKeyJwk">
         <rect width="163.73" height="32.54" x="1437.5" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -733,7 +733,7 @@
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m874.59 656.46 7.05-8.67-.22 5.58 4.34 3.53Z" pointer-events="all"/>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1132.62 572.1Q1061 641 882.25 656.53" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m874.77 657.18 9.53-5.84-2.05 5.19 2.92 4.77Z" pointer-events="all"/>
-    <a xlink:href="https://w3.org/2018/credentials/#digestMultibase">
+    <a xlink:href="https://w3id.org/security#digestMultibase">
         <rect width="163.73" height="32.54" x="559.45" y="550.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">

--- a/vocab/security/vocabulary.svg
+++ b/vocab/security/vocabulary.svg
@@ -338,7 +338,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="650" y="452" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security#expires">
+    <a xlink:href="https://w3id.org/security#expiration">
         <rect width="163.73" height="32.54" x="881" y="238" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -346,13 +346,13 @@
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                expires
+                                expiration
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="963" y="259" font-family="Helvetica" font-size="16" text-anchor="middle">expires</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="963" y="259" font-family="Helvetica" font-size="16" text-anchor="middle">expiration</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#nonce">

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -4,7 +4,7 @@ vocab:
 
 prefix:
   - id: cred
-    value: https://w3.org/2018/credentials#
+    value: https://www.w3.org/2018/credentials#
 
 ontology:
   - property: dc:title

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -209,6 +209,7 @@ property:
   - id: expiration
     label: Expiration time for a proof or verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires
+    comment: This property is often expressed using `expires` as a shortened term in JSON-LD, for historical purposes; since this shortened term and its mapping to this property are in significant use in the ecosystem, this inconsistency between the short term name and the property identifier is expected.
     domain:
       - sec:Proof
       - sec:VerificationMethod

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -209,7 +209,7 @@ property:
   - id: expiration
     label: Expiration time for a proof or verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires
-    comment: This property is often expressed using `expires` as a shortened term in JSON-LD, for historical purposes; since this shortened term and its mapping to this property are in significant use in the ecosystem, this inconsistency between the short term name and the property identifier is expected.
+    comment: Historically, this property has often been expressed using `expires` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`expires`) and the property identifier (`...#expiration`) is expected and should not trigger an error.
     domain:
       - sec:Proof
       - sec:VerificationMethod

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -206,7 +206,7 @@ property:
     domain: sec:Proof
     range: xsd:dateTime
 
-  - id: expires
+  - id: expiration
     label: Expiration time for a proof or verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires
     domain:


### PR DESCRIPTION
This is an ***editorial*** cleanup for the URL-s in the voabulary, following the separate discussion in https://github.com/w3c/vc-data-model/pull/1296#discussion_r1357635748 but also https://github.com/w3c/vc-data-model/pull/1296#discussion_r1357668261.

The generated files are not on `/TR`, so this PR does not affect the current CR review.