### PR TITLE
Add potential for Controller Document spec at risk marker.

### DIFF
--- a/index.html
+++ b/index.html
@@ -960,6 +960,19 @@ contain <a>verification relationships</a> that explicitly permit the use of
 certain <a>verification methods</a> for specific purposes.
         </p>
 
+        <p class="issue atrisk"
+          title="Potential for stand-alone Controller Document specification">
+This section on Controller Documents has been identified as potentially useful
+for other securing mechanisms such as [[?VC-JOSE-COSE]]. There is a possibility
+that this section will be moved to an independent Controller Document
+specification, which would then be normatively referenced by this specification.
+If this migration occurs, it is expected that there will be little to no
+impact on implementations as the normative statements that exist in this
+section will remain in the new document or be preserved in this document as
+an additional set of requirements on top of the base Controller Document
+specification.
+        </p>
+
         <div class="issue">Add examples of common Controller documents, such as
 controller documents published on a ledger-based registry, or on a mutable medium in
 combination with an integrity protection mechanism such as Hashlinks.

--- a/index.html
+++ b/index.html
@@ -962,15 +962,15 @@ certain <a>verification methods</a> for specific purposes.
 
         <p class="issue atrisk"
           title="Potential for stand-alone Controller Document specification">
-This section on Controller Documents has been identified as potentially useful
-for other securing mechanisms such as [[?VC-JOSE-COSE]]. There is a possibility
-that this section will be moved to an independent Controller Document
-specification, which would then be normatively referenced by this specification.
-If this migration occurs, it is expected that there will be little to no
-impact on implementations as the normative statements that exist in this
-section will remain in the new document or be preserved in this document as
-an additional set of requirements on top of the base Controller Document
-specification.
+There are lots of commonalities between this section on Controller Documents and
+similar sections in other securing mechanisms such as [[?VC-JOSE-COSE]], or
+similar concepts in specifications such as [[?DID-CORE]]. The Working Group is
+currently discussing the possibility to move this section to an independent
+Controller Document specification that can be referenced normatively. If this
+migration occurs, it is expected that there will be little to no impact on
+implementations as the normative statements that exist in this section will
+remain in the new document or be preserved in this document as an additional set
+of requirements on top of the base Controller Document specification.
         </p>
 
         <div class="issue">Add examples of common Controller documents, such as

--- a/index.html
+++ b/index.html
@@ -962,14 +962,14 @@ certain <a>verification methods</a> for specific purposes.
 
         <p class="issue atrisk"
           title="Potential for stand-alone Controller Document specification">
-There are lots of commonalities between this section on Controller Documents and
-similar sections in other securing mechanisms such as [[?VC-JOSE-COSE]], or
-similar concepts in specifications such as [[?DID-CORE]]. The Working Group is
-currently discussing the possibility to move this section to an independent
+There are many commonalities between this section on Controller Documents and
+similar sections in other securing mechanisms such as [[?VC-JOSE-COSE]], as well as 
+sections on similar concepts in specifications such as [[?DID-CORE]]. The Working Group is
+currently discussing the possibility of moving this section to an independent
 Controller Document specification that can be referenced normatively. If this
 migration occurs, it is expected that there will be little to no impact on
-implementations as the normative statements that exist in this section will
-remain in the new document or be preserved in this document as an additional set
+implementations, as the normative statements that exist in this section will
+remain in this or the new document as an additive set
 of requirements on top of the base Controller Document specification.
         </p>
 


### PR DESCRIPTION
This PR attempts to address issue #216 by adding an issue marker noting that there is a potential for a stand-alone Controller Document specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/219.html" title="Last updated on Oct 24, 2023, 9:50 PM UTC (59e284a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/219/5429118...59e284a.html" title="Last updated on Oct 24, 2023, 9:50 PM UTC (59e284a)">Diff</a>