### PR TITLE
Binding Proof Chains Together

### DIFF
--- a/index.html
+++ b/index.html
@@ -3118,10 +3118,11 @@ Set <var>allProofs</var> to </var><var>securedDocument</var>.<var>proof</var>.
           <li>
 For each <var>proof</var> in <var>allProofs</var>, do the following steps:
           </li>
-          <li>
+          <ol class="algorithm">
+            <li>
 Let <var>matchingProofs</var> be an empty list.
-          </li>
-          <li>
+            </li>
+            <li>
 If <var>proof</var> contains a <code>previousProof</code> attribute and that
 attribute is a string, add the element from <var>allProofs</var> with an
 <code>id</code> attribute matching <code>previousProof</code> to matchingProofs.
@@ -3133,25 +3134,26 @@ If the <code>previousProof</code> attribute is an array, add each element from
 of that array. If any matches are missing, an error MUST be raised and SHOULD
 convey an error type of
 <a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
-          </li>
-          <li>
+            </li>
+            <li>
 Let <var>unsecuredDocument</var> be a copy of <var>securedDocument</var> with
 the proof value removed and then set <var>unsecuredDocument.proof</var>
 to <var>matchingProofs</var>.
-          <li>
+            </li>
+            <li>
 Run steps 2 through 4 to validate the contents of <var>proof</var>.
-          </li>
-          </li>
-          <li>
+            </li>
+            <li>
 Run steps 6 through 11 of the algorithm in
 section <a href="#verify-proof"></a>; if no exceptions are raised, associate
 the <var>isProofVerified</var> value with this <var>proof</var>.
-            <p class="note">
+              <p class="note">
 We specifically use the value of <var>unsecuredDocument</var> as set above,
 rather than using the value from step 5 of the algorithm in section
 <a href="#verify-proof"></a>.
-            </p>
-          </li>
+              </p>
+            </li>
+          </ol>
           <li>
 Return the <var>allProofs</var> along with each proof's associated
 <var>isProofVerified</var> information.

--- a/index.html
+++ b/index.html
@@ -2990,9 +2990,9 @@ convey an error type of
           <li>
 Set <var>unsecuredDocument.proof</var> to <var>matchingProofs</var>.
             <p class="note">
-This step is critical to <q>bind</q> the previous proofs to the document prior
-to signing. The <var>proof</var> value for the document will be updated in a
-later step of this algorithm.
+This step is critical, as it <q>binds</q> the previous proofs to the document
+prior to signing. The <var>proof</var> value for the document will be updated
+in a later step of this algorithm.
             </p>
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -3107,11 +3107,14 @@ Return <var>isProofVerified</var> as the <a>verification result</a>.
 In a proof set or proof chain, a <a>secured data document</a> has a
 <code>proof</code> attribute which contains a list of proofs
 (<var>allProofs</var>).
-The following algorithm specifies how to check the authenticity and
-integrity of a <a>secured data document</a> by verifying each
-proof in the <var>allProofs</var>. Required inputs are a
+The following algorithm gives one method to check the authenticity and
+integrity of a <a>secured data document</a>. It does this by verifying every
+proof in <var>allProofs</var>. Other approaches are possible, particularly if
+it is desired to only verify a subset of the proofs contained in
+<var>allProfs</var>. Required inputs are a
 <a>secured data document</a> (<var>securedDocument</var>). A list of
-verification results is produced as output.
+verification results corresponding to each proof in <var>allProofs</var> is
+produced as output.
         </p>
         <ol class="algorithm">
           <li>

--- a/index.html
+++ b/index.html
@@ -2983,7 +2983,9 @@ attribute is a string, add the element from <var>allProofs</var> with an
 <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
 If the <code>previousProof</code> attribute is an array, add each element from
 <var>allProofs</var> with an <code>id</code> attribute that matches an element
-of that array. If any matches are missing, an error MUST be raised and SHOULD
+of that array. If any elements of <code>previousProof</code> array have an
+<code>id</code> attribute that does not match the <code>id</code> attribute
+of any element of <var>allProofs</var>, an error MUST be raised and SHOULD
 convey an error type of
 <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -2971,15 +2971,35 @@ with the <var>proof</var> attribute removed. Let <var>output</var> be a copy of
 the <var>unsecuredDocument</var>.
           </li>
           <li>
+Let <var>matchingProofs</var> be an empty set.
+          </li>
+          <li>
 If <var>options</var> contains a <code>previousProof</code> attribute and that
-attribute is a string, check whether
-an element of the <var>allProofs</var> has a matching <code>id</code> attribute.
-If not, an error MUST be raised and SHOULD convey an error type of
-<a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>. If the
-<code>previousProof</code> attribute is an array, check that each element of that
-array is a string which matches the <code>id</code> attribute of an element
-of the <var>allProofs</var>. If not, an error MUST be raised and SHOULD convey
-an error type of <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
+attribute is a string, add the element from <var>allProofs</var> with a matching
+<code>id</code> attribute to matchingProofs. If it does not exist, an error MUST
+be raised and SHOULD convey an error type of
+<a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
+If the <code>previousProof</code> attribute is an array, add an element from
+<var>allProofs</var> with an <code>id</code> attribute that matches each element
+of that array. If any matches are missing, an error MUST be raised and SHOULD
+convey an error type of
+<a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
+          </li>
+          <li>
+For each element <var>mp</var> of <var>matchingProofs</var>, if there are any,
+recursively run the previous step on <var>mp.previousProof</var> if it exist.
+            <p class="note">
+This steps insures that all proof dependencies are added regardless of the depth
+of the proof chain.
+            </p>
+          </li>
+          <li>
+Set <var>unsecuredDocument.proof</var> to <var>matchingProofs</var>.
+            <p class="note">
+This step is critical to <q>bind</q> the previous proofs to the document prior
+to signing. The <var>proof</var> value for the document will be updated in a
+later step of this algorithm.
+            </p>
           </li>
           <li>
 Run steps 2 through 8 of the algorithm in section <a href="#add-proof"></a>. If

--- a/index.html
+++ b/index.html
@@ -3122,21 +3122,48 @@ verification results is produced as output.
 Set <var>allProofs</var> to </var><var>securedDocument</var>.<var>proof</var>.
           </li>
           <li>
-For each <var>proof</var> in <var>allProofs</var>, run steps 2 through 11 of the algorithm in
-section <a href="#verify-proof"></a>; if no exceptions are raised, associate
-the <var>isProofVerified</var> value with this <var>proof</var>.
+For each <var>proof</var> in <var>allProofs</var> do the following steps:
           </li>
           <li>
-For each <var>proof</var> in <var>allProofs</var> that contains a
-<code>previousProof</code> attribute, modify the associated
-<var>isProofVerified</var> by iteratively checking that the proof identified by
-the <code>id</code> value in <var>previousProof</var>, along with every
-<code>previousProof</code> up the chain, is valid. If <code>previousProof</code> is an
-array, then all previous proofs identified by the array elements
-MUST be valid for the current proof to be considered valid. Cycle detection,
-such as keeping a list of previously visited proofs, MUST be used to guard
-against proof cycles. If a cycle is detected in a proof chain,
-then a `PROOF_CHAIN_CYCLE_ERROR` MUST be raised.
+Let <var>matchingProofs</var> be an empty set.
+          </li>
+          <li>
+If <var>proof</var> contains a <code>previousProof</code> attribute and that
+attribute is a string, add the element from <var>allProofs</var> with a matching
+<code>id</code> attribute to matchingProofs. If it does not exist, an error MUST
+be raised and SHOULD convey an error type of
+<a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
+If the <code>previousProof</code> attribute is an array, add an element from
+<var>allProofs</var> with an <code>id</code> attribute that matches each element
+of that array. If any matches are missing, an error MUST be raised and SHOULD
+convey an error type of
+<a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
+          </li>
+          <li>
+For each element <var>mp</var> of <var>matchingProofs</var>, if there are any,
+recursively run the previous step on <var>mp.previousProof</var> if it exist.
+Cycle detection, such as keeping a list of previously visited proofs, MUST be
+used to guard against proof cycles. If a cycle is detected in a proof chain,
+then a <a href="#PROOF_CHAIN_CYCLE_ERROR">PROOF_CHAIN_CYCLE_ERROR</a> MUST be
+raised.
+          </li>
+          <li>
+Let <var>unsecuredDocument</var> be a copy of <var>securedDocument</var> with
+the proof value removed and then set <var>unsecuredDocument.proof</var>
+to <var>matchingProofs</var>.
+          <li>
+Run steps 2 through 4 to validate the contents of <var>proof</var>.
+          </li>
+          </li>
+          <li>
+Run steps 6 through 11 of the algorithm in
+section <a href="#verify-proof"></a>; if no exceptions are raised, associate
+the <var>isProofVerified</var> value with this <var>proof</var>.
+            <p class="note">
+We specifically use the value of <var>unsecuredDocument</var> as set above
+rather than using value from step 5 of the algorithm in section
+<a href="#verify-proof"></a>
+            </p>
           </li>
           <li>
 Return the <var>allProofs</var> along with each proof's associated
@@ -3329,6 +3356,11 @@ The <a>verification method</a> in a <a>controller document</a> was not
 associated using the expected <a>verification relationship</a> as expressed
 in the `proofPurpose` property in the proof. See Section
 <a href="#retrieve-verification-method"></a>.
+          </dd>
+          <dt id="PROOF_CHAIN_CYCLE_ERROR">PROOF_CHAIN_CYCLE_ERROR (-26)</dt>
+          <dd>
+A proof cycle was detected during the verification of a proof set or proof
+chain. See Section <a href="#verify-proof-sets-and-chains"></a>.
           </dd>
         </dl>
       </section>

--- a/index.html
+++ b/index.html
@@ -3107,11 +3107,11 @@ Return <var>isProofVerified</var> as the <a>verification result</a>.
 In a proof set or proof chain, a <a>secured data document</a> has a
 <code>proof</code> attribute which contains a list of proofs
 (<var>allProofs</var>).
-The following algorithm gives one method to check the authenticity and
-integrity of a <a>secured data document</a>. It does this by verifying every
+The following algorithm provides one method of checking the authenticity and
+integrity of a <a>secured data document</a>, achieved by verifying every
 proof in <var>allProofs</var>. Other approaches are possible, particularly if
-it is desired to only verify a subset of the proofs contained in
-<var>allProfs</var>. Required inputs are a
+it is only desired to verify a subset of the proofs contained in
+<var>allProfs</var>. Required input is a
 <a>secured data document</a> (<var>securedDocument</var>). A list of
 verification results corresponding to each proof in <var>allProofs</var> is
 produced as output.

--- a/index.html
+++ b/index.html
@@ -3125,7 +3125,8 @@ Let <var>matchingProofs</var> be an empty list.
             <li>
 If <var>proof</var> contains a <code>previousProof</code> attribute and that
 attribute is a string, add the element from <var>allProofs</var> with an
-<code>id</code> attribute matching <code>previousProof</code> to matchingProofs.
+<code>id</code> attribute matching <code>previousProof</code> to
+<code>matchingProofs</code>.
 If a proof with <code>id</code> does not exist in <var>allProofs</var>, an error
 MUST be raised and SHOULD convey an error type of
 <a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.

--- a/index.html
+++ b/index.html
@@ -3111,7 +3111,13 @@ The following algorithm provides one method of checking the authenticity and
 integrity of a <a>secured data document</a>, achieved by verifying every
 proof in <var>allProofs</var>. Other approaches are possible, particularly if
 it is only desired to verify a subset of the proofs contained in
-<var>allProfs</var>. Required input is a
+<var>allProfs</var>. If another approach is taken to verify only a subset of the
+proofs, then it is important to note any proof with <code>previousProof</code>
+in that subset can only be considered verified if the proofs it references are
+also considered verified.
+        </p>
+        <p>
+Required input is a
 <a>secured data document</a> (<var>securedDocument</var>). A list of
 verification results corresponding to each proof in <var>allProofs</var> is
 produced as output.

--- a/index.html
+++ b/index.html
@@ -3134,7 +3134,9 @@ MUST be raised and SHOULD convey an error type of
 <a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
 If the <code>previousProof</code> attribute is an array, add each element from
 <var>allProofs</var> with an <code>id</code> attribute that matches an element
-of that array. If any matches are missing, an error MUST be raised and SHOULD
+of that array. If any element of <code>previousProof</code> array has an
+<code>id</code> attribute that does not match the <code>id</code> attribute
+of any element of <var>allProofs</var>, an error MUST be raised and SHOULD
 convey an error type of
 <a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
             </li>

--- a/index.html
+++ b/index.html
@@ -3111,10 +3111,10 @@ The following algorithm provides one method of checking the authenticity and
 integrity of a <a>secured data document</a>, achieved by verifying every
 proof in <var>allProofs</var>. Other approaches are possible, particularly if
 it is only desired to verify a subset of the proofs contained in
-<var>allProfs</var>. If another approach is taken to verify only a subset of the
-proofs, then it is important to note any proof with <code>previousProof</code>
-in that subset can only be considered verified if the proofs it references are
-also considered verified.
+<var>allProofs</var>. If another approach is taken to verify only a subset of the
+proofs, then it is important to note that any proof in that subset with a
+<code>previousProof</code> can only be considered verified if the proofs it
+references are also considered verified.
         </p>
         <p>
 Required input is a

--- a/index.html
+++ b/index.html
@@ -3349,11 +3349,6 @@ associated using the expected <a>verification relationship</a> as expressed
 in the `proofPurpose` property in the proof. See Section
 <a href="#retrieve-verification-method"></a>.
           </dd>
-          <dt id="PROOF_CHAIN_CYCLE_ERROR">PROOF_CHAIN_CYCLE_ERROR (-26)</dt>
-          <dd>
-A proof cycle was detected during the verification of a proof set or proof
-chain. See Section <a href="#verify-proof-sets-and-chains"></a>.
-          </dd>
         </dl>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -2983,7 +2983,7 @@ attribute is a string, add the element from <var>allProofs</var> with an
 <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
 If the <code>previousProof</code> attribute is an array, add each element from
 <var>allProofs</var> with an <code>id</code> attribute that matches an element
-of that array. If any elements of <code>previousProof</code> array have an
+of that array. If any element of <code>previousProof</code> array has an
 <code>id</code> attribute that does not match the <code>id</code> attribute
 of any element of <var>allProofs</var>, an error MUST be raised and SHOULD
 convey an error type of

--- a/index.html
+++ b/index.html
@@ -2971,27 +2971,21 @@ with the <var>proof</var> attribute removed. Let <var>output</var> be a copy of
 the <var>unsecuredDocument</var>.
           </li>
           <li>
-Let <var>matchingProofs</var> be an empty set.
+Let <var>matchingProofs</var> be an empty list.
           </li>
           <li>
 If <var>options</var> contains a <code>previousProof</code> attribute and that
-attribute is a string, add the element from <var>allProofs</var> with a matching
-<code>id</code> attribute to matchingProofs. If it does not exist, an error MUST
-be raised and SHOULD convey an error type of
+attribute is a string, add the element from <var>allProofs</var> with an
+<code>id</code> attribute matching <code>previousProof</code> to
+<var>matchingProofs</var>. If a proof with
+<code>id</code> equal to <code>previousProof</code>does not exist in
+<var>allProofs</var>, an error MUST be raised and SHOULD convey an error type of
 <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
-If the <code>previousProof</code> attribute is an array, add an element from
-<var>allProofs</var> with an <code>id</code> attribute that matches each element
+If the <code>previousProof</code> attribute is an array, add each element from
+<var>allProofs</var> with an <code>id</code> attribute that matches an element
 of that array. If any matches are missing, an error MUST be raised and SHOULD
 convey an error type of
 <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
-          </li>
-          <li>
-For each element <var>mp</var> of <var>matchingProofs</var>, if there are any,
-recursively run the previous step on <var>mp.previousProof</var> if it exist.
-            <p class="note">
-This steps insures that all proof dependencies are added regardless of the depth
-of the proof chain.
-            </p>
           </li>
           <li>
 Set <var>unsecuredDocument.proof</var> to <var>matchingProofs</var>.
@@ -3122,30 +3116,23 @@ verification results is produced as output.
 Set <var>allProofs</var> to </var><var>securedDocument</var>.<var>proof</var>.
           </li>
           <li>
-For each <var>proof</var> in <var>allProofs</var> do the following steps:
+For each <var>proof</var> in <var>allProofs</var>, do the following steps:
           </li>
           <li>
-Let <var>matchingProofs</var> be an empty set.
+Let <var>matchingProofs</var> be an empty list.
           </li>
           <li>
 If <var>proof</var> contains a <code>previousProof</code> attribute and that
-attribute is a string, add the element from <var>allProofs</var> with a matching
-<code>id</code> attribute to matchingProofs. If it does not exist, an error MUST
-be raised and SHOULD convey an error type of
+attribute is a string, add the element from <var>allProofs</var> with an
+<code>id</code> attribute matching <code>previousProof</code> to matchingProofs.
+If a proof with <code>id</code> does not exist in <var>allProofs</var>, an error
+MUST be raised and SHOULD convey an error type of
 <a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
-If the <code>previousProof</code> attribute is an array, add an element from
-<var>allProofs</var> with an <code>id</code> attribute that matches each element
+If the <code>previousProof</code> attribute is an array, add each element from
+<var>allProofs</var> with an <code>id</code> attribute that matches an element
 of that array. If any matches are missing, an error MUST be raised and SHOULD
 convey an error type of
 <a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
-          </li>
-          <li>
-For each element <var>mp</var> of <var>matchingProofs</var>, if there are any,
-recursively run the previous step on <var>mp.previousProof</var> if it exist.
-Cycle detection, such as keeping a list of previously visited proofs, MUST be
-used to guard against proof cycles. If a cycle is detected in a proof chain,
-then a <a href="#PROOF_CHAIN_CYCLE_ERROR">PROOF_CHAIN_CYCLE_ERROR</a> MUST be
-raised.
           </li>
           <li>
 Let <var>unsecuredDocument</var> be a copy of <var>securedDocument</var> with
@@ -3160,9 +3147,9 @@ Run steps 6 through 11 of the algorithm in
 section <a href="#verify-proof"></a>; if no exceptions are raised, associate
 the <var>isProofVerified</var> value with this <var>proof</var>.
             <p class="note">
-We specifically use the value of <var>unsecuredDocument</var> as set above
-rather than using value from step 5 of the algorithm in section
-<a href="#verify-proof"></a>
+We specifically use the value of <var>unsecuredDocument</var> as set above,
+rather than using the value from step 5 of the algorithm in section
+<a href="#verify-proof"></a>.
             </p>
           </li>
           <li>


### PR DESCRIPTION
The current algorithm in section 4.4 Add Proof Set/Chain doesn't bind proofs in a chain with each other. This slight modification of the algorithm achieves this result. This PR:

1. Modifies section 4.4 Add Proof Set/Chain to provide this binding. Thanks to @dlongley for suggesting the mechanism.
2. Modifies section 4.6 Verify Proof Sets and Chains to work with the improved algorithm
3. Modifies section 4.8 Processing Errors to formally define the `PROOF_CHAIN_CYCLE_ERROR` that was in the text but not defined.

Files for generating test vectors for these updated procedures have been created at https://github.com/Wind4Greg/EdDSA-Test-Vectors/tree/proof-chains.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/224.html" title="Last updated on Dec 12, 2023, 11:14 PM UTC (ba5482e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/224/8859155...Wind4Greg:ba5482e.html" title="Last updated on Dec 12, 2023, 11:14 PM UTC (ba5482e)">Diff</a>