### PR TITLE
Define proof properties no longer defined in VCDM

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,7 +587,9 @@ information is provided using Linked Data vocabularies such as the
 
         <p>
 When expressing a <a>data integrity proof</a> on an object, a
-<dfn class="lint-ignore">`proof`</dfn> property MUST be used. If present, its
+<dfn class="lint-ignore">`proof`</dfn> property MUST be used.
+The `proof` property within a Verifiable Credential is a named graph.
+If present, its
 value MUST be either a single object, or an unordered set of objects, expressed
 using the properties below:
         </p>


### PR DESCRIPTION
This adds descriptions of `proof` to Data Integrity that https://github.com/w3c/vc-data-model/pull/1397 removes from the VC Data Model when they were not already also described in Data Integrity.  (Almost everything removed from VCDM already had duplicate descriptions in DI.)

This is part of addressing https://github.com/w3c/vc-data-model/issues/1377.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/vc-data-integrity/pull/230.html" title="Last updated on Dec 19, 2023, 10:30 PM UTC (befce9e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/230/30281b9...selfissued:befce9e.html" title="Last updated on Dec 19, 2023, 10:30 PM UTC (befce9e)">Diff</a>