### PR TITLE
Editorial: Remove extra quotes like |suite|'s'.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3099,11 +3099,11 @@ Let <var>unsecuredDocument</var> be a copy of <var>securedDocument</var> with
 the `proof` value removed.
           </li>
           <li>
-Let <var>transformedData</var> be the result of running |suite|'s'
+Let <var>transformedData</var> be the result of running |suite|'s
 [=cryptographic suite/transform=] algorithm on the <var>unsecuredDocument</var>.
         </li>
           <li>
-Let <var>hashData</var> be the result of running |suite|'s'
+Let <var>hashData</var> be the result of running |suite|'s
 [=cryptographic suite/hash=] algorithm on the <var>transformedData</var>.
           </li>
           <li>


### PR DESCRIPTION
Fixing a mistake from #226 that @TallTed [noticed](https://github.com/w3c/vc-data-integrity/pull/226#discussion_r1439880637).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/vc-data-integrity/pull/233.html" title="Last updated on Jan 2, 2024, 10:09 PM UTC (42f20c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/233/3d8a467...jyasskin:42f20c3.html" title="Last updated on Jan 2, 2024, 10:09 PM UTC (42f20c3)">Diff</a>