### PR TITLE
i18n Improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,8 +637,10 @@ by a verifier during the verification process.
           <dt><dfn class="lint-ignore">created</dfn></dt>
           <dd>
 The date and time the proof was created is OPTIONAL and, if included, MUST be
-specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string and SHOULD include a
-zone offset, preferably Z (meaning UTC).
+specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string, either in Universal
+Coordinated Time (UTC), denoted by a Z at the end of the value, or with a time
+zone offset relative to UTC. Time values that are incorrectly serialized without
+an offset MUST be interpreted as UTC.
           </dd>
 
           <dt id="defn-proof-expires">expires</dt>

--- a/index.html
+++ b/index.html
@@ -646,8 +646,10 @@ an offset MUST be interpreted as UTC.
           <dt id="defn-proof-expires">expires</dt>
           <dd>
 The `expires` property is OPTIONAL and, if present, specifies when the proof
-expires. If present, it MUST be an [[XMLSCHEMA11-2]] `dateTimeStamp` string and
-SHOULD include a zone offset, preferably Z (meaning UTC).
+expires. If present, it MUST be an [[XMLSCHEMA11-2]] `dateTimeStamp` string,
+either in Universal Coordinated Time (UTC), denoted by a Z at the end of the
+value, or with a time zone offset relative to UTC. Time values that are
+incorrectly serialized without an offset MUST be interpreted as UTC.
           </dd>
 
           <dt id="defn-domain">domain</dt>

--- a/index.html
+++ b/index.html
@@ -637,13 +637,15 @@ by a verifier during the verification process.
           <dt><dfn class="lint-ignore">created</dfn></dt>
           <dd>
 The date and time the proof was created is OPTIONAL and, if included, MUST be
-specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string.
+specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string and SHOULD include a
+zone offset, preferably Z (meaning UTC).
           </dd>
 
           <dt id="defn-proof-expires">expires</dt>
           <dd>
-The `expires` property is OPTIONAL. If present, it MUST be an [[XMLSCHEMA11-2]]
-`dateTimeStamp` string specifying when the proof expires.
+The `expires` property is OPTIONAL and, if present, specifies when the proof
+expires. If present, it MUST be an [[XMLSCHEMA11-2]] `dateTimeStamp` string and
+SHOULD include a zone offset, preferably Z (meaning UTC).
           </dd>
 
           <dt id="defn-domain">domain</dt>


### PR DESCRIPTION
Add time zone info to optional `created` and `expires` properties for i18n compatibility. 

This PR addresses issue https://github.com/w3c/vc-di-bbs/issues/114 in the `vc-di-bbs` specification. The solution is not for that specification to redefine the `created` and `expires` properties but to reference the `vc-data-integrity` specification for them.  The i18n discussion on that issue recommended adding time zone information to these fields as this PR does.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/240.html" title="Last updated on Feb 9, 2024, 6:55 PM UTC (f3ba9b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/240/8543e69...Wind4Greg:f3ba9b2.html" title="Last updated on Feb 9, 2024, 6:55 PM UTC (f3ba9b2)">Diff</a>