### PR TITLE
Added the proposed sentence for verification method type of issue 245

### DIFF
--- a/index.html
+++ b/index.html
@@ -1178,15 +1178,18 @@ documents, for which it is optional. See section [[[#proofs]]].
                 <dd>
                   <p>
 The value of the `id` property for a [=verification method=] MUST be a
-[=string=] that conforms to the conforms to the [[URL]] syntax.
+[=string=] that conforms to the [[URL]] syntax.
                   </p>
                 </dd>
                 <dt>type</dt>
                 <dd>
-The value of the `type` property MUST be a [=string=] that references exactly
-one [=verification method=] type. In order to maximize global
-interoperability, the [=verification method=] type SHOULD be registered in
-the Data Integrity Specification Registries [TBD -- DIS-REGISTRIES].
+The value of the `type` property MUST be a [=string=] that conforms to the [[URL]] syntax,
+and that references exactly one [=verification method=] type. 
+This specification defines two
+verification methods types (<a href="#multikey">`Multikey`</a> and <a href="#jsonwebkey">`JsonWebKey`</a>);
+others may be defined by the community.
+In order to maximize global interoperability, the [=verification method=] type SHOULD be registered in
+the Data Integrity Specification Registries [TBD -- DIS-REGISTRIES]. 
                 </dd>
                 <dt><span id="defn-controller">controller</span></dt>
                 <dd>

--- a/index.html
+++ b/index.html
@@ -1187,10 +1187,11 @@ The value of the `type` property MUST be a [=string=] that either conforms to th
 [[URL]] syntax or maps (through interpretation of the `@context` property) to a [[URL]],
 and that references exactly one [=verification method=] type. 
 This specification defines two
-verification methods types (<a href="#multikey">`Multikey`</a> and <a href="#jsonwebkey">`JsonWebKey`</a>);
-others may be defined by the community.
-In order to maximize global interoperability, the [=verification method=] type SHOULD be registered in
-the Data Integrity Specification Registries [TBD -- DIS-REGISTRIES]. 
+[=verification method=] types (<a href="#multikey">`Multikey`</a> and
+<a href="#jsonwebkey">`JsonWebKey`</a>); others may be defined by the community.
+To maximize global interoperability, such community-defined [=verification method=]
+types SHOULD be registered in the Data Integrity Specification Registries
+[TBD -- DIS-REGISTRIES]. 
                 </dd>
                 <dt><span id="defn-controller">controller</span></dt>
                 <dd>

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,8 @@ The value of the `id` property for a [=verification method=] MUST be a
                 </dd>
                 <dt>type</dt>
                 <dd>
-The value of the `type` property MUST be a [=string=] that conforms to the [[URL]] syntax,
+The value of the `type` property MUST be a [=string=] that either conforms to the
+[[URL]] syntax or maps (through interpretation of the `@context` property) to a [[URL]],
 and that references exactly one [=verification method=] type. 
 This specification defines two
 verification methods types (<a href="#multikey">`Multikey`</a> and <a href="#jsonwebkey">`JsonWebKey`</a>);

--- a/index.html
+++ b/index.html
@@ -1188,10 +1188,9 @@ The value of the `type` property MUST be a [=string=] that either conforms to th
 and that references exactly one [=verification method=] type. 
 This specification defines two
 [=verification method=] types (<a href="#multikey">`Multikey`</a> and
-<a href="#jsonwebkey">`JsonWebKey`</a>); others may be defined by the community.
+<a href="#jsonwebkey">`JsonWebKey`</a>); others might be defined by the community.
 To maximize global interoperability, such community-defined [=verification method=]
-types SHOULD be registered in the Data Integrity Specification Registries
-[TBD -- DIS-REGISTRIES]. 
+types SHOULD be registered in the [[[VC-SPECS]]] [[[?VC-SPECS]]]. 
                 </dd>
                 <dt><span id="defn-controller">controller</span></dt>
                 <dd>


### PR DESCRIPTION
The `type` property's definition is more precise and added two forward references to multikey and jwk. I also removed a duplicate term in another sentence in the section

Should take care of #245, which should be closed if and when this PR is merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/254.html" title="Last updated on Apr 28, 2024, 2:17 PM UTC (bff8918)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/254/f9a94c5...bff8918.html" title="Last updated on Apr 28, 2024, 2:17 PM UTC (bff8918)">Diff</a>