### PR TITLE
Updated the section on multikey

### DIFF
--- a/index.html
+++ b/index.html
@@ -1337,7 +1337,7 @@ Multibase value as described in Section [[[#multibase-0]]].
             </p>
 
             <p>
-When specifing a `Multikey`, the object takes the following form:
+When specifying a `Multikey`, the object takes the following form:
             </p>
 
             <dl>
@@ -1348,14 +1348,23 @@ The value of the `type` property MUST contain the string `Multikey`.
               <dt><dfn class="lint-ignore">publicKeyMultibase</dfn></dt>
               <dd>
 The `publicKeyMultibase` property is OPTIONAL. If present, its value MUST be a
-Multibase encoded value as described in Section [[[#multibase-0]]].
+Multibase encoded value as described in Section [[[#multibase-0]]]. The value format itself,
+which is encoded in Multibase, MUST be defined by the cryptographic suite specification used by 
+the [=verification method=].
               </dd>
               <dt><dfn class="lint-ignore">secretKeyMultibase</dfn></dt>
               <dd>
 The `secretKeyMultibase` property is OPTIONAL. If present, its value MUST be a
-Multibase encoded value as described in Section [[[#multibase-0]]].
+Multibase encoded value as described in Section [[[#multibase-0]]]. The value format itself,
+which is encoded in Multibase, MUST be defined by the cryptographic suite specification used by
+the [=verification method=].
               </dd>
             </dl>
+
+            <p>
+              Implementations that perform JSON-LD processing MUST use the `https://w3id.org/security/multikey/v1` context URL for 
+              Multikey. 
+            </p>
 
             <p>
 An example of a Multikey is provided below:
@@ -1388,7 +1397,7 @@ include <em>symmetric keys</em> and <em>private keys</em>.
             <pre class="example nohighlight"
               title="Multikey encoding of a Ed25519 secret key">
 {
-  "@context": ["https://w3id.org/security/suites/secrets/v1"],
+  "@context": ["https://w3id.org/security/multikey/v1"],
   "id": "did:example:123456789abcdefghi#keys-1",
   "type": "Multikey",
   "controller": "did:example:123456789abcdefghi",
@@ -1445,13 +1454,18 @@ representing a JSON Web Key that conforms to [[RFC7517]].
             </dl>
 
             <p>
+              Implementations that perform JSON-LD processing MUST use the `https://w3id.org/security/jwk/v1` context URL for
+              JsonWebKey.
+            </p>
+
+            <p>
 An example of an object that conforms to this data model is provided below:
             </p>
 
             <pre class="example nohighlight"
               title="JSON Web Key encoding of an Ed25519 public key">
 {
-  "@context": ["https://www.w3.org/ns/security/jwk/v1"],
+  "@context": ["https://w3id.org/security/jwk/v1"],
   "id": "did:example:123456789abcdefghi#key-1",
   "type": "JsonWebKey",
   "controller": "did:example:123456789abcdefghi",
@@ -1490,7 +1504,7 @@ referred to as <em>private keys</em>.
             <pre class="example nohighlight"
               title="JSON Web Key encoding of an Ed25519 secret key">
 {
-  "@context": ["https://www.w3.org/ns/security/jwk/v1"],
+  "@context": ["https://w3id.org/security/jwk/v1"],
   "id": "did:example:123456789abcdefghi#key-1",
   "type": "JsonWebKey",
   "controller": "did:example:123456789abcdefghi",

--- a/index.html
+++ b/index.html
@@ -1348,14 +1348,14 @@ The value of the `type` property MUST contain the string `Multikey`.
               <dt><dfn class="lint-ignore">publicKeyMultibase</dfn></dt>
               <dd>
 The `publicKeyMultibase` property is OPTIONAL. If present, its value MUST be a
-Multibase encoded value as described in Section [[[#multibase-0]]]. The value format itself,
+Multibase-encoded value as described in Section [[[#multibase-0]]]. The value format itself,
 which is encoded in Multibase, MUST be defined by the cryptographic suite specification used by 
 the [=verification method=].
               </dd>
               <dt><dfn class="lint-ignore">secretKeyMultibase</dfn></dt>
               <dd>
 The `secretKeyMultibase` property is OPTIONAL. If present, its value MUST be a
-Multibase encoded value as described in Section [[[#multibase-0]]]. The value format itself,
+Multibase-encoded value as described in Section [[[#multibase-0]]]. The value format itself,
 which is encoded in Multibase, MUST be defined by the cryptographic suite specification used by
 the [=verification method=].
               </dd>


### PR DESCRIPTION
This PR is, primarily, to cover issue #251:

- It adds a remark both for `publicKeyMultibase` and `secretKeyMultibase` that the value, which is encoded in Multibase, must be specified by the cryptosuite spec
- It also adds, both for Multibase and Multikey, that a specific context file must be used for JSON-LD processing (that was not made clear before...)
- There were some erroneous context files in the examples...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/257.html" title="Last updated on Mar 15, 2024, 12:04 PM UTC (f1e7e42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/257/2098949...f1e7e42.html" title="Last updated on Mar 15, 2024, 12:04 PM UTC (f1e7e42)">Diff</a>