### PR TITLE
Changed the proofPurpose range in the vocabulary - issue 248

### DIFF
--- a/vocab/security/template.html
+++ b/vocab/security/template.html
@@ -254,18 +254,18 @@
         <summary>Overview diagram of the vocabulary (without the reserved and deprecated items, error codes, and `xsd` datatypes).</summary>
         <p>
           The diagram uses boxes, ellipses, and connecting lines with different "styles" 
-          (border color, end marker, line type) to differentiate their semantic meaning; 
-          these styles identify "Property", "Class", or "Datatype" via the shapes used for the 
-          graph nodes, and "Superclass", "Domain Of", "Range", "Type", or "Contains", 
-          via the styles of the connecting lines. In particular, <em>all</em> ellipses are styled as "Class".
+          (border color, end marker, line type) to differentiate their semantic meaning:
+          "Property", "Class", and "Datatype" are identified by the shape of the 
+          graph node (e.g., an ellipse signifies a "Class"); "Superclass", "Domain Of", "Range",
+          "Type", and "Contains" relationships are identified by the style of the connecting line.
           These style names are used in the explanation text that follows, below.
         </p>
         <p>
           The diagram is roughly divided into three sections — lower left, lower right, and upper.
           To make this description easier to understand, these sections will be respectively referred to
           as the "Proof", "Verification Method", and "Verification Relationship" sections.
-          The three sections are connected by lines of different types; additionally, one box,
-          labeled as "multibase", and having shape "Datatype", is shared by the two lower sections 
+          Shapes in the three sections are connected by lines of different styles; additionally, one box,
+          labeled as "multibase" and shaped as "Datatype", bridges the two lower sections 
           ("Proof" and "Verification Method").
         </p>
         <p>
@@ -276,27 +276,27 @@
           <h3>Proof Section</h3>
           <p>
             The left side of the section contains another ellipse, 
-            labeled as "ProofGraph", and connected to the ellipse labeled as "Proof" with a connecting line, 
-            styled as "Contains". 
-            A separate box, styled as "Property" and labeled as "proof", is connected to the ellipse labeled as "ProofGraph",
-            with a connecting line styled as "Range".
+            labeled as "ProofGraph", and connected with a line
+            styled as "Contains" to the "Proof" ellipse. 
+            A separate box, styled as "Property" and labeled as "proof", is connected
+            with a line styled as "Range" to the "ProofGraph" ellipse.
           </p>
           <p>
             There are two more ellipses in this section, 
-            labeled as "Ed25519Signature2020" and "DataIntegrityProof", respectively,
-            each connected to the ellipse labeled as "Proof" through connecting lines styled as "Superclass". 
-            The ellipse labeled as "DataIntegrityProof" is also connected to a box, styled as "Property" and labeled as 
-            "cryptosuite", with a connecting line styled as "Domain Of". 
+            labeled as "Ed25519Signature2020" and "DataIntegrityProof", and
+            each connected to the "Proof" ellipse with lines styled as "Superclass". 
+            The "DataIntegrityProof" ellipse is also connected to a box, styled as "Property" and labeled as 
+            "cryptosuite", with a line styled as "Domain Of". 
             The "cryptosuite" Property box is connected to a shape, styled as "Datatype" and labeled as "cryptosuiteString", 
-            with a connecting  line styled as "Range".
+            with a line styled as "Range".
           </p>
           <p>
             The right side of the section contains a column of labeled boxes, all styled as "Property".
             The labels, from top to bottom, are "previousProof", "domain", "challenge", "nonce", "created", and "proofValue". 
-            The ellipse, labeled as "Proof", is connected to all of these with connecting lines styled as "Domain Of". 
-            The box labeled as "previousProof" is also connected to the ellipse, labeled as "Proof", with a connecting line styled as "Range". 
-            The box labeled as "proofValue" is connected to a shape, styled as "Datatype" and labeled as "multibase", with a connecting line styled as "Range".
-            Finally, another box, styled as "Property" and labeled as "digestMultibase", is connected to the same "multibase" shape, styled as "Datatype", with a connecting line styled as "Range".
+            The "Proof" ellipse is connected to all of these boxes with lines styled as "Domain Of". 
+            The "previousProof" box is also connected to the "Proof" ellipse, with a line styled as "Range". 
+            The "proofValue" box is connected to a shape, styled as "Datatype" and labeled as "multibase", with a line styled as "Range".
+            Finally, the same "multibase" "Datatype" shape is connected to another box, styled as "Property" and labeled as "digestMultibase", with a line styled as "Range".
           </p>
         </section>
         <section>
@@ -305,34 +305,35 @@
           <p>
             The left side of this section contains a column of three labeled boxes, all styled as "Property". 
             The labels, from top to bottom, are "expires", "controller", and "revoked". 
-            Each of these is connected to the ellipse, labeled "VerificationMethod", with connecting lines styled as "Domain Of".
-            The "expires" "Property" box is also connected to the ellipse labeled "Proof" in the Proof section, 
-            with a connecting line styled as "Domain Of".
+            Each of these is connected to the "VerificationMethod" ellipse, with a line styled as "Domain Of".
+            The "expires" "Property" box is also connected to the "Proof" ellipse (in the Proof section), 
+            with a line styled as "Domain Of".
           </p>
 
           <p>
             There is also a distinct box, styled as "Property" and labeled as "verificationMethod". 
-            This box is connected to the ellipse, labeled as "VerificationMethod", with a connecting line styled as "Range".
+            This "verificationMethod" box is connected to the "VerificationMethod" 
+ellipse, with a connecting line styled as "Range".
           </p>
 
           <p>
             The middle of this section contains three more ellipses, labeled as "Multikey, "Ed25519VerificationKey2020", 
-            and "JsonWebKey", respectively.
-            Each of these is connected to the ellipse, labeled as "VerificationMethod", with a connecting line styled as "Superclass".
+            and "JsonWebKey".
+            Each of these is connected to the "VerificationMethod" ellipse, with a line styled as "Superclass".
           </p>
 
           <p>
             Two boxes, styled as "Property" and labeled as "secretKeyMultibase" and "publicKeyMultibase", 
-            respectively, are connected to the ellipse labeled as "Multikey" with a connecting line styled as "Domain Of".
-            Each of these boxes is also connected to the shape in the Proof section, styled as "Datatype" 
-            and labeled as "multibase", with connecting lines styled as "Range".
+            are connected to the ellipse labeled as "Multikey" with a line styled as "Domain Of".
+            Each of these boxes is also connected to the "multibase" "Datatype" shape in the Proof section, 
+            with lines styled as "Range".
           </p>
 
           <p>
             Finally, two boxes, styled as "Property" and labeled as "secretKeyJwk" 
-            and "publicKeyJwk", respectively, are connected to the ellipse labeled "JsonWebKey",
-            with a connecting line styled as "Domain Of". 
-            Both boxes are also connected to a shape, styled as "Datatype" and labeled as "rdf:JSON", with connecting 
+            and "publicKeyJwk", are connected to the "JsonWebKey" ellipse,
+            with a line styled as "Domain Of". 
+            Both boxes are also connected to a shape, styled as "Datatype" and labeled as "rdf:JSON", with
             lines styled as "Range".
           </p>
 
@@ -342,20 +343,20 @@
           <p>
             The left side of the section contains a single box, styled as "Property"
             and labeled as "proofPurpose". 
-            This box is connected to the ellipse, labeled as "VerificationRelationship", 
-            with a connecting line styled as "Range". 
-            It is also connected to the ellipse in the Proof section, labeled "Proof", 
-            with a connecting line styled as "Domain Of".
+            This box is connected to the "VerificationRelationship" ellipse,
+            with a line styled as "Range". 
+            It is also connected to the "Proof" ellipse in the Proof section,
+            with a line styled as "Domain Of".
           </p>
 
           <p>
             The right side of the section contains a column of labeled boxes,
             all styled as "Property". 
             The labels, from top to bottom, are "verificationMethod", "authentication", "assertionMethod", "capabilityDelegation", "capabilityInvocation", and "keyAgreement".
-            Each of these boxes is connected to the ellipse in the Verification Method section, labeled "VerificationMethod", 
-            with a connecting line styled as "Range". 
-            Finally, each of these boxes is also connected to the ellipse, labeled "VerificationRelationship",
-            with a connecting line styled as "Type".
+            Each of these boxes is connected to the "VerificationMethod" ellipse in the Verification Method section,
+            with a line styled as "Range". 
+            Finally, each of these boxes is also connected to the "VerificationRelationship" ellipse,
+            with a line styled as "Type".
           </p>
         </section>
       </details>

--- a/vocab/security/template.html
+++ b/vocab/security/template.html
@@ -255,128 +255,107 @@
         <p>
           The diagram uses boxes, ellipses, and connecting lines with different "styles" 
           (border color, end marker, line type) to differentiate their semantic meaning; 
-          these styles identify Property, Class, or Datatype, via the shapes used for the 
-          graph nodes, and Superclass, Domain Of, Range, Type, or Contains, via the styles of the connecting lines.
+          these styles identify "Property", "Class", or "Datatype" via the shapes used for the 
+          graph nodes, and "Superclass", "Domain Of", "Range", "Type", or "Contains", 
+          via the styles of the connecting lines. In particular, <em>all</em> ellipses are styled as "Class".
           These style names are used in the explanation text that follows, below.
         </p>
         <p>
-          The diagram is roughly divided into three sections — lower left, lower right, and upper.
+          The diagram is roughly divided into three sections — lower left, lower right, and upper.
           To make this description easier to understand, these sections will be respectively referred to
-          as the "Proof Section", "Verification Section", and "Verification Relationship Section".
+          as the "Proof", "Verification Method", and "Verification Relationship" sections.
           The three sections are connected by lines of different types; additionally, one box,
-          labeled as "multibase" and having shape "Datatype", is shared by the two lower sections ("Proof" and "Verification").
+          labeled as "multibase", and having shape "Datatype", is shared by the two lower sections 
+          ("Proof" and "Verification Method").
         </p>
         <p>
-          Each of these sections has an ellipse at the top, styled as Class, 
-          and respectively labeled as "Proof", "VerificationMethod", and "VerificationRelationship".
+          Each of these sections has an ellipse at the top, labeled as "Proof", "VerificationMethod", 
+          and "VerificationRelationship", respectively.
         </p>
         <section>
           <h3>Proof Section</h3>
           <p>
-            The left side of the Proof Section contains another ellipse, 
-            styled as Class and labeled as "ProofGraph", and connected
-            to the ellipse labeled as "Proof" with a connecting line styled as Contains. 
-            There is also a box, styled as Property and labeled as "proof",
-            connected to the ellipse labeled as "ProofGraph"
-            with a connecting line styled as Range.
+            The left side of the section contains another ellipse, 
+            labeled as "ProofGraph", and connected to the ellipse labeled as "Proof" with a connecting line, 
+            styled as "Contains". 
+            A separate box, styled as "Property" and labeled as "proof", is connected to the ellipse labeled as "ProofGraph",
+            with a connecting line styled as "Range".
           </p>
           <p>
-            There are two more ellipses in this section, styled as Class 
-            and labeled as "Ed25519Signature2020" and "DataIntegrityProof",
-            each connected to the ellipse labeled as "Proof"
-            with connecting lines styled as Superclass. 
-            The ellipse labeled as "DataIntegrityProof" is
-            also connected to a box styled as Property, 
-            and labeled as "cryptosuite", with a connecting 
-            line styled as Domain Of. The "cryptosuite" Property box
-            is connected to a shape
-            styled as Datatype and labeled as
-            "cryptosuiteString", with a connecting 
-            line styled as Range.
+            There are two more ellipses in this section, 
+            labeled as "Ed25519Signature2020" and "DataIntegrityProof", respectively,
+            each connected to the ellipse labeled as "Proof" through connecting lines styled as "Superclass". 
+            The ellipse labeled as "DataIntegrityProof" is also connected to a box, styled as "Property" and labeled as 
+            "cryptosuite", with a connecting line styled as "Domain Of". 
+            The "cryptosuite" Property box is connected to a shape, styled as "Datatype" and labeled as "cryptosuiteString", 
+            with a connecting  line styled as "Range".
           </p>
           <p>
-            The right side of the Section contains a column of labeled boxes, 
-            all styled as Property. The labels, from top to 
-            bottom, are "previousProof", "domain", "challenge",
-            "nonce", "created", and "proofValue". 
-            The ellipse labeled as "Proof" is connected to all of these with 
-            connecting lines styled as "Domain Of". 
-            The box labeled as "previousProof" is also connected to the ellipse 
-            labeled as "Proof" with a connecting line styled as Range. 
-            The box labeled as "proofValue" is connected to a shape styled as Datatype
-            and labeled as "multibase", with a connecting line styled as Range.
-            Finally, another box, styled as Property and labeled as "digestMultibase",
-            is connected to the same "multibase" Datatype shape with
-            a connecting line styled as Range.
+            The right side of the section contains a column of labeled boxes, all styled as "Property".
+            The labels, from top to bottom, are "previousProof", "domain", "challenge", "nonce", "created", and "proofValue". 
+            The ellipse, labeled as "Proof", is connected to all of these with connecting lines styled as "Domain Of". 
+            The box labeled as "previousProof" is also connected to the ellipse, labeled as "Proof", with a connecting line styled as "Range". 
+            The box labeled as "proofValue" is connected to a shape, styled as "Datatype" and labeled as "multibase", with a connecting line styled as "Range".
+            Finally, another box, styled as "Property" and labeled as "digestMultibase", is connected to the same "multibase" shape, styled as "Datatype", with a connecting line styled as "Range".
           </p>
         </section>
         <section>
-          <h3>Verification Section</h3>
+          <h3>Verification Method Section</h3>
 
           <p>
-            The left side of this Section contains a column of three labeled 
-            boxes, all styled as Property. The labels, from top to bottom, are 
-            "expires", "controller", and "revoked". Each of these is connected
-            to the ellipse labeled "VerificationMethod",
-            with connecting lines styled as Domain Of.
-            The "expires" Property box is also connected to the ellipse 
-            labeled "Proof" in the Proof Section, with a connecting line 
-            styled as Domain Of.
+            The left side of this section contains a column of three labeled boxes, all styled as "Property". 
+            The labels, from top to bottom, are "expires", "controller", and "revoked". 
+            Each of these is connected to the ellipse, labeled "VerificationMethod", with connecting lines styled as "Domain Of".
+            The "expires" "Property" box is also connected to the ellipse labeled "Proof" in the Proof section, 
+            with a connecting line styled as "Domain Of".
           </p>
 
           <p>
-            There is also a distinct box, styled as Property and labeled as "verificationMethod". 
-            This box is connected to the ellipse labeled as "VerificationMethod" with a 
-            connecting line styled as Range.
+            There is also a distinct box, styled as "Property" and labeled as "verificationMethod". 
+            This box is connected to the ellipse, labeled as "VerificationMethod", with a connecting line styled as "Range".
           </p>
 
           <p>
-            The middle of this section contains three more ellipses,
-            styled as Class, and labeled as 
-            "Multikey, "Ed25519VerificationKey2020", and "JsonWebKey".
-            Each of these is connected to 
-            the ellipse labeled as "VerificationMethod"
-            with a connecting line styled as Superclass.
+            The middle of this section contains three more ellipses, labeled as "Multikey, "Ed25519VerificationKey2020", 
+            and "JsonWebKey", respectively.
+            Each of these is connected to the ellipse, labeled as "VerificationMethod", with a connecting line styled as "Superclass".
           </p>
 
           <p>
-            Two boxes, styled as Property and labeled as "secretKeyMultibase"
-            and "publicKeyMultibase", are connected to the ellipse
-            labeled as "Multikey" with a connecting line styled as Domain Of.
-            Each of these boxes is also connected to the shape in the Proof
-            section styled as Datatype and labeled as "multibase",
-            with connecting lines styled as Range.
+            Two boxes, styled as "Property" and labeled as "secretKeyMultibase" and "publicKeyMultibase", 
+            respectively, are connected to the ellipse labeled as "Multikey" with a connecting line styled as "Domain Of".
+            Each of these boxes is also connected to the shape in the Proof section, styled as "Datatype" 
+            and labeled as "multibase", with connecting lines styled as "Range".
           </p>
 
           <p>
-            Finally, two boxes, styled as Property and labeled "secretKeyJwk" 
-            and "publicKeyJwk", are connected to the ellipse labeled "JsonWebKey"
-            with a connecting line styled as Domain Of. 
-            Each of these boxes is also connected to
-            a shape styled as Datatype and labeled as "rdf:JSON",
-            with connecting lines styled as Range.
+            Finally, two boxes, styled as "Property" and labeled as "secretKeyJwk" 
+            and "publicKeyJwk", respectively, are connected to the ellipse labeled "JsonWebKey",
+            with a connecting line styled as "Domain Of". 
+            Both boxes are also connected to a shape, styled as "Datatype" and labeled as "rdf:JSON", with connecting 
+            lines styled as "Range".
           </p>
 
         </section>
         <section>
           <h3>Verification Relationship Section</h3>
           <p>
-            The left side of the section contains a single box, styled as Property
-            and labeled as "proofPurpose". This box is connected to the ellipse
-            "VerificationRelationship" with a connecting line styled as Range, 
-            and is also connected to the ellipse labeled "Proof" in the Proof Section, 
-            with a connecting line styled as Domain Of.
+            The left side of the section contains a single box, styled as "Property"
+            and labeled as "proofPurpose". 
+            This box is connected to the ellipse, labeled as "VerificationRelationship", 
+            with a connecting line styled as "Range". 
+            It is also connected to the ellipse in the Proof section, labeled "Proof", 
+            with a connecting line styled as "Domain Of".
           </p>
 
           <p>
-            The right side of this Section contains a column of labeled boxes,
-            all styled as Property. The labels, from top to bottom, are
-            "verificationMethod", "authentication", "assertionMethod",
-            "capabilityDelegation", "capabilityInvocation", and "keyAgreement".
-            Each of these boxes is connected to the ellipse labeled "VerificationMethod" in the 
-            Verification section, with a connecting line styled as Range, 
-            and to the ellipse labeled "VerificationRelationship"
-            with a connecting line styled as Type.
+            The right side of the section contains a column of labeled boxes,
+            all styled as "Property". 
+            The labels, from top to bottom, are "verificationMethod", "authentication", "assertionMethod", "capabilityDelegation", "capabilityInvocation", and "keyAgreement".
+            Each of these boxes is connected to the ellipse in the Verification Method section, labeled "VerificationMethod", 
+            with a connecting line styled as "Range". 
+            Finally, each of these boxes is also connected to the ellipse, labeled "VerificationRelationship",
+            with a connecting line styled as "Type".
           </p>
         </section>
       </details>

--- a/vocab/security/template.html
+++ b/vocab/security/template.html
@@ -155,10 +155,6 @@
         is used to include them in the RDFS representations).
       </p>
       <figure id="vocabulary-diagram" style="text-align:center">
-        <!--
-                Original diagram is in https://drive.google.com/file/d/1-kg7AzhahSzIwiIHeh5ANGJB_JK-kugs/view?usp=drive_link
-                using the draw.io (diagrams.net plugin for google).
-              -->
         <div data-include="vocabulary.svg" data-include-replace="true" data-oninclude="massageSVGLinks"></div>
         <figcaption>Overview diagram of the vocabulary (without the reserved and deprecated items, error codes, and `xsd` datatypes).<br />
           A separate, stand-alone <a href="vocabulary.svg" target="_blank">SVG version</a> of the diagram, as well as a <a
@@ -260,16 +256,19 @@
           The diagram uses boxes, ellipses, and connecting lines with different "styles" 
           (border color, end marker, line type) to differentiate their semantic meaning; 
           these styles identify Property, Class, or Datatype, via the shapes used for the 
-          graph nodes, and Superclass, Domain Of, Range, or Contains, via the styles of the connecting lines.
+          graph nodes, and Superclass, Domain Of, Range, Type, or Contains, via the styles of the connecting lines.
           These style names are used in the explanation text that follows, below.
         </p>
         <p>
-          The diagram is roughly divided into left and right sections 
-          (although there are some common nodes; see later).
-          To make this description easier to understand, these will be referred to as the 
-          "Proof Section" and the "Verification Section". 
+          The diagram is roughly divided into (lower) left and (lower) right sections, and a top section.
+          These sections are connected by connecting lines of different types, and there is also one 
+          box, labeled as "multibase" and of a shape Datatype, that is shared by the two lower sections.
+          To make this description easier to understand, these sections will be referred to as the 
+          "Proof Section", "Verification Section", and "Verification Relationship Section", respectively. 
+        </p>
+        <p>
           Each of these sections has an ellipse at the top, styled as Class, 
-          and respectively labeled as "Proof" and "VerificationMethod".
+          and respectively labeled as "Proof", "VerificationMethod", and "VerificationRelationship".
         </p>
         <section>
           <h3>Proof Section</h3>
@@ -298,7 +297,7 @@
           <p>
             The right side of the Section contains a column of labeled boxes, 
             all styled as Property. The labels, from top to 
-            bottom, are "previousProof", "domain", "challenge", "proofPurpose", 
+            bottom, are "previousProof", "domain", "challenge",
             "nonce", "created", "proofValue". 
             The ellipse labeled as "Proof" is connected to all of these with 
             connecting lines styled as Domain Of. 
@@ -312,17 +311,8 @@
           </p>
         </section>
         <section>
-          <h3>VerificationMethod Section</h3>
+          <h3>Verification Section</h3>
 
-          <p>
-            The right side of this Section contains a column of labeled boxes, 
-            all styled as Property. The labels, from top to bottom, are 
-            "verificationMethod", "authentication", "assertionMethod", 
-            "capabilityDelegation", "capabilityInvocation", and "keyAgreement". 
-            Each of these boxes is connected to 
-            the ellipse labeled "VerificationMethod",
-            with a connecting line styled as Range.
-          </p>
           <p>
             The left side of this Section contains a column of three labeled 
             boxes, all styled as Property. The labels, from top to bottom, are 
@@ -335,7 +325,13 @@
           </p>
 
           <p>
-            The middle of this section contains three ellipses,
+            There is also a separate box, styled as Property and labeled as "verificationMethod". 
+            This box is connected to the ellipse labeled as "VerificationMethod" with a 
+            connecting line styled as Range.
+          </p>
+
+          <p>
+            The middle of this section contains three more ellipses,
             styled as Class, and labeled as 
             "Multikey, "Ed25519VerificationKey2020", and "JsonWebKey".
             Each of these is connected to 
@@ -362,11 +358,28 @@
           </p>
 
         </section>
+        <section>
+          <h3>Verification Relationship Section</h3>
+          <p>
+            The left side of the section contains a single box, styled as Property
+            and labeled as "proofPurpose". This box is connected to the ellipse
+            "VerificationRelationship" with a connecting line styled as Range, 
+            and is also connected to the ellipse labeled "Proof" in the Proof Section, 
+            with a connecting line styled as Domain Of.
+          </p>
 
-
+          <p>
+            The right side of this Section contains a column of labeled boxes,
+            all styled as Property. The labels, from top to bottom, are
+            "verificationMethod", "authentication", "assertionMethod",
+            "capabilityDelegation", "capabilityInvocation", and "keyAgreement".
+            Each of these boxes is connected to the ellipse labeled "VerificationMethod" in the 
+            Verification section, with a connecting line styled as Range, 
+            and to the ellipse labeled "VerificationRelationship"
+            with a connecting line styled as Type.
+          </p>
+        </section>
       </details>
     </section>
-
-
   </body>
 </html>

--- a/vocab/security/template.html
+++ b/vocab/security/template.html
@@ -260,11 +260,11 @@
           These style names are used in the explanation text that follows, below.
         </p>
         <p>
-          The diagram is roughly divided into (lower) left and (lower) right sections, and a top section.
-          These sections are connected by connecting lines of different types, and there is also one 
-          box, labeled as "multibase" and of a shape Datatype, that is shared by the two lower sections.
-          To make this description easier to understand, these sections will be referred to as the 
-          "Proof Section", "Verification Section", and "Verification Relationship Section", respectively. 
+          The diagram is roughly divided into three sections — lower left, lower right, and upper.
+          To make this description easier to understand, these sections will be respectively referred to
+          as the "Proof Section", "Verification Section", and "Verification Relationship Section".
+          The three sections are connected by lines of different types; additionally, one box,
+          labeled as "multibase" and having shape "Datatype", is shared by the two lower sections ("Proof" and "Verification").
         </p>
         <p>
           Each of these sections has an ellipse at the top, styled as Class, 
@@ -298,9 +298,9 @@
             The right side of the Section contains a column of labeled boxes, 
             all styled as Property. The labels, from top to 
             bottom, are "previousProof", "domain", "challenge",
-            "nonce", "created", "proofValue". 
+            "nonce", "created", and "proofValue". 
             The ellipse labeled as "Proof" is connected to all of these with 
-            connecting lines styled as Domain Of. 
+            connecting lines styled as "Domain Of". 
             The box labeled as "previousProof" is also connected to the ellipse 
             labeled as "Proof" with a connecting line styled as Range. 
             The box labeled as "proofValue" is connected to a shape styled as Datatype
@@ -325,7 +325,7 @@
           </p>
 
           <p>
-            There is also a separate box, styled as Property and labeled as "verificationMethod". 
+            There is also a distinct box, styled as Property and labeled as "verificationMethod". 
             This box is connected to the ellipse labeled as "VerificationMethod" with a 
             connecting line styled as Range.
           </p>

--- a/vocab/security/vocabulary.drawio
+++ b/vocab/security/vocabulary.drawio
@@ -1,20 +1,17 @@
-<mxfile host="Electron" modified="2024-02-04T15:27:01.598Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.21 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="WWMKmeTrPV5vMB27TpU0" version="22.1.21" type="device">
+<mxfile host="Electron" modified="2024-03-19T13:55:48.914Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="9qW_w_5ziSf6Vmgx4YGB" version="24.0.4" type="device">
   <diagram name="Page-1" id="hQ0IBVJ5jpEcegRt-_B3">
-    <mxGraphModel dx="1943" dy="1368" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+    <mxGraphModel dx="2044" dy="2169" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-115" value="" style="group" parent="1" vertex="1" connectable="0">
-          <mxGeometry x="127" y="812.5" width="1340" height="54.5" as="geometry" />
+        <mxCell id="lNdu0edYDnSajEhI0VVL-20" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="44.16388539042816" y="812.5" width="1460" height="54.5" as="geometry" />
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-84" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" parent="Uf8WLKuzS3drS_BCJ-BJ-115" vertex="1">
-          <mxGeometry width="1330" height="54.5" as="geometry" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-84" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1">
+          <mxGeometry width="1453" height="54.5" as="geometry" />
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-114" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-115" vertex="1" connectable="0">
-          <mxGeometry x="11.5" y="7.25" width="1328.5" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-108" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
-          <mxGeometry x="1138.5" width="190" height="40" as="geometry" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-108" value="" style="group" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1" connectable="0">
+          <mxGeometry x="1270" y="7.25" width="190" height="40" as="geometry" />
         </mxCell>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-109" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;endArrow=classic;endFill=0;" parent="Uf8WLKuzS3drS_BCJ-BJ-108" edge="1">
           <mxGeometry relative="1" as="geometry">
@@ -25,8 +22,8 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-110" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Graph containment&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;" parent="Uf8WLKuzS3drS_BCJ-BJ-108" vertex="1">
           <mxGeometry y="-6" width="70" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-87" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
-          <mxGeometry y="1.4375" width="160" height="37.125" as="geometry" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-87" value="" style="group" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1" connectable="0">
+          <mxGeometry x="11.5" y="8.6875" width="160" height="37.125" as="geometry" />
         </mxCell>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-88" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-87" vertex="1">
           <mxGeometry x="60" y="4.95" width="100" height="28.004625" as="geometry" />
@@ -34,8 +31,8 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-89" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-87" vertex="1">
           <mxGeometry width="50" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-90" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
-          <mxGeometry x="187.5" y="1.4375" width="170" height="37.125" as="geometry" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-90" value="" style="group" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1" connectable="0">
+          <mxGeometry x="188" y="8.6875" width="170" height="37.125" as="geometry" />
         </mxCell>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-91" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#330000;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-90" vertex="1">
           <mxGeometry x="83" y="4.95" width="80" height="23.685750000000002" as="geometry" />
@@ -43,8 +40,8 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-92" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-90" vertex="1">
           <mxGeometry width="70" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-93" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
-          <mxGeometry x="571.5" y="1.4375" width="170" height="37.125" as="geometry" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-93" value="" style="group" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1" connectable="0">
+          <mxGeometry x="552" y="8.6875" width="170" height="37.125" as="geometry" />
         </mxCell>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-94" value="" style="endArrow=classic;html=1;rounded=0;endFill=1;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-93" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
@@ -55,8 +52,8 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-95" value="Superclass" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-93" vertex="1">
           <mxGeometry x="-5" width="80" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-96" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
-          <mxGeometry x="781.5" y="1.4375" width="136" height="37.125" as="geometry" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-96" value="" style="group" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1" connectable="0">
+          <mxGeometry x="751" y="8.6875" width="136" height="37.125" as="geometry" />
         </mxCell>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-97" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=none;startFill=0;endArrow=classic;endFill=1;strokeColor=#FF3333;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;dashPattern=1 1;" parent="Uf8WLKuzS3drS_BCJ-BJ-96" edge="1">
           <mxGeometry relative="1" as="geometry">
@@ -71,8 +68,8 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-98" value="Domain" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-96" vertex="1">
           <mxGeometry width="60" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-99" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
-          <mxGeometry x="961.5" y="1.4375" width="160" height="37.125" as="geometry" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-99" value="" style="group" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1" connectable="0">
+          <mxGeometry x="921" y="8.6875" width="160" height="37.125" as="geometry" />
         </mxCell>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-100" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#0000CC;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-99" edge="1">
           <mxGeometry relative="1" as="geometry">
@@ -83,8 +80,8 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-101" value="Range" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="Uf8WLKuzS3drS_BCJ-BJ-99" vertex="1">
           <mxGeometry width="60" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-113" value="" style="group" parent="Uf8WLKuzS3drS_BCJ-BJ-114" vertex="1" connectable="0">
-          <mxGeometry x="382.5" width="163.39999999999998" height="40" as="geometry" />
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-113" value="" style="group" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1" connectable="0">
+          <mxGeometry x="374" y="7.25" width="163.39999999999998" height="40" as="geometry" />
         </mxCell>
         <UserObject label="" id="Uf8WLKuzS3drS_BCJ-BJ-111">
           <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-113" vertex="1">
@@ -94,11 +91,18 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-112" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" parent="Uf8WLKuzS3drS_BCJ-BJ-113" vertex="1">
           <mxGeometry width="90" height="40" as="geometry" />
         </mxCell>
-        <UserObject label="&lt;i&gt;VerificationMethod&lt;/i&gt;" link="https://w3id.org/security#VerificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-37">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="1104.668136020151" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
-          </mxCell>
-        </UserObject>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-19" value="" style="group" parent="lNdu0edYDnSajEhI0VVL-20" vertex="1" connectable="0">
+          <mxGeometry x="1112" y="12.25" width="142" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-17" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#006601;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;dashPattern=1 4;" parent="lNdu0edYDnSajEhI0VVL-19" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="62" y="18.5625" as="sourcePoint" />
+            <mxPoint x="142" y="18.5625" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-18" value="Type" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lNdu0edYDnSajEhI0VVL-19" vertex="1">
+          <mxGeometry width="50" height="30" as="geometry" />
+        </mxCell>
         <UserObject label="&lt;i&gt;controller&lt;/i&gt;" link="https://w3id.org/security#controller" id="Uf8WLKuzS3drS_BCJ-BJ-44">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="868.003765743073" y="298.9969117647059" width="163.7314231738035" height="32.536500000000004" as="geometry" />
@@ -109,66 +113,12 @@
             <mxGeometry x="868.003765743073" y="347.99470588235295" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-48" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-38" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="1092.2207178841309" y="192.87113309466875" as="sourcePoint" />
-            <mxPoint x="1206.1624685138538" y="192.87113309466875" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="1328" y="100" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-49" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-39" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="1140.0954030226699" y="183.30157427113934" as="sourcePoint" />
-            <mxPoint x="1254.0371536523928" y="183.30157427113934" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="1318" y="120" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-50" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-40" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="1140.0954030226699" y="202.44069191819818" as="sourcePoint" />
-            <mxPoint x="1254.0371536523928" y="202.44069191819818" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="1328" y="150" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-51" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-41" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="1140.0954030226699" y="278.9971625064335" as="sourcePoint" />
-            <mxPoint x="1254.0371536523928" y="278.9971625064335" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="1318" y="170" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-52" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-42" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="1197.5450251889167" y="326.84495662408057" as="sourcePoint" />
-            <mxPoint x="1311.4867758186397" y="326.84495662408057" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="1308" y="200" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-53" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-43" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="1152.0640743073047" y="384.07091838878637" as="sourcePoint" />
-            <mxPoint x="1266.0058249370275" y="384.07091838878637" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="1298" y="230" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-54" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-44" target="Uf8WLKuzS3drS_BCJ-BJ-37" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="1394.7887279596976" y="336.2258823529412" as="sourcePoint" />
             <mxPoint x="1216.6948992443324" y="336.2258823529412" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="1128" y="140" />
+              <mxPoint x="1135" y="140" />
             </Array>
           </mxGeometry>
         </mxCell>
@@ -210,11 +160,6 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;Proof&lt;/i&gt;" link="https://w3id.org/security#Proof" id="Uf8WLKuzS3drS_BCJ-BJ-1">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;pointer-events=&quot;all&quot;" parent="1" vertex="1">
-            <mxGeometry x="234.92600755667502" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
-          </mxCell>
-        </UserObject>
         <UserObject label="&lt;i&gt;ProofGraph&lt;/i&gt;" link="https://w3id.org/security#ProofGraph" id="Uf8WLKuzS3drS_BCJ-BJ-2">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="62.57714105793451" y="163.97382352941176" width="208.7336272040302" height="46.89083823529412" as="geometry" />
@@ -223,7 +168,7 @@
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-3" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;endArrow=classic;endFill=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-2" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="254.07588161209065" y="128.56645588235295" as="sourcePoint" />
-            <mxPoint x="464.72449622166243" y="125.69558823529412" as="targetPoint" />
+            <mxPoint x="464.72449622166243" y="125.69558823529411" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;proof&lt;/i&gt;" link="https://w3id.org/security#proof" id="Uf8WLKuzS3drS_BCJ-BJ-5">
@@ -239,22 +184,22 @@
         </mxCell>
         <UserObject label="&lt;i&gt;domain&lt;/i&gt;" link="https://w3id.org/security#domain" id="Uf8WLKuzS3drS_BCJ-BJ-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="555.3489294710328" y="143" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+            <mxGeometry x="555.3489294710328" y="210" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;challenge&lt;/i&gt;" link="https://w3id.org/security#challenge" id="Uf8WLKuzS3drS_BCJ-BJ-8">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="555.3489294710328" y="248" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+            <mxGeometry x="555.3489294710328" y="268" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;previousProof&lt;/i&gt;" link="https://w3id.org/security#previousProof" id="Uf8WLKuzS3drS_BCJ-BJ-9">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="555.3489294710328" y="96.8925" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+            <mxGeometry x="555.3489294710328" y="152.9125" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;proofPurpose&lt;br&gt;&lt;/i&gt;" link="https://w3id.org/security#proofPurpose" id="Uf8WLKuzS3drS_BCJ-BJ-10">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="555.3489294710328" y="299.15" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+            <mxGeometry x="469.99892947103274" y="-166.45999999999998" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;proofValue&lt;/i&gt;" link="https://w3id.org/security#proofValue" id="Uf8WLKuzS3drS_BCJ-BJ-11">
@@ -269,21 +214,19 @@
         </UserObject>
         <UserObject label="&lt;i&gt;nonce&lt;/i&gt;" link="https://w3id.org/security#nonce" id="Uf8WLKuzS3drS_BCJ-BJ-13">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="555.3489294710328" y="347" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+            <mxGeometry x="555.3489294710328" y="325" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;created&lt;/i&gt;" link="https://w3id.org/security#created" id="Uf8WLKuzS3drS_BCJ-BJ-14">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="555.3489294710328" y="394" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+            <mxGeometry x="555.3489294710328" y="383" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-15" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-7" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="441.7446473551637" y="163.97382352941176" as="sourcePoint" />
             <mxPoint x="263.65081863979844" y="163.97382352941176" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="478" y="120" />
-            </Array>
+            <Array as="points" />
           </mxGeometry>
         </mxCell>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-16" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;entryX=1;entryY=1;entryDx=0;entryDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-8" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
@@ -291,7 +234,7 @@
             <mxPoint x="493.44930730478586" y="122.8247205882353" as="sourcePoint" />
             <mxPoint x="330.6753778337531" y="106.5564705882353" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="478" y="150" />
+              <mxPoint x="460" y="150" />
             </Array>
           </mxGeometry>
         </mxCell>
@@ -299,17 +242,15 @@
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="480.04439546599497" y="183.1129411764706" as="sourcePoint" />
             <mxPoint x="301.9505667506297" y="183.1129411764706" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="508" y="100" />
-            </Array>
+            <Array as="points" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-18" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-10" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-18" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-10" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="503.0242443324937" y="132.3942794117647" as="sourcePoint" />
             <mxPoint x="358.44269521410575" y="96.02995588235294" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="493.44930730478586" y="202.2520588235294" />
+              <mxPoint x="500" y="-40" />
             </Array>
           </mxGeometry>
         </mxCell>
@@ -322,12 +263,12 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-20" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-12" edge="1">
+        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-20" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-12" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="868.3089294710326" y="227.1282500000002" as="sourcePoint" />
             <mxPoint x="413.9768556909135" y="69.89352290842726" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="538" y="230" />
+              <mxPoint x="790" y="50" />
             </Array>
           </mxGeometry>
         </mxCell>
@@ -336,7 +277,7 @@
             <mxPoint x="541.3239924433249" y="403.21279411764704" as="sourcePoint" />
             <mxPoint x="273.2257556675063" y="269.2389705882353" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="448" y="270" />
+              <mxPoint x="470" y="250" />
             </Array>
           </mxGeometry>
         </mxCell>
@@ -345,7 +286,7 @@
             <mxPoint x="441.7446473551637" y="288.3780882352941" as="sourcePoint" />
             <mxPoint x="263.65081863979844" y="288.3780882352941" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="438" y="290" />
+              <mxPoint x="450" y="290" />
             </Array>
           </mxGeometry>
         </mxCell>
@@ -399,42 +340,6 @@
             <mxPoint x="661.0107052896725" y="566.0839272123158" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-34" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;edgeStyle=orthogonalEdgeStyle;curved=1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-9" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="843.8920025188916" y="192.87113309466875" as="sourcePoint" />
-            <mxPoint x="957.8337531486145" y="192.87113309466875" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <UserObject label="&lt;i&gt;verificationMethod&lt;/i&gt;" link="https://w3id.org/security#verificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-38">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="1380" y="89.76" width="210" height="32.54" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;i&gt;authentication&lt;/i&gt;" link="https://w3id.org/security#authentication" id="Uf8WLKuzS3drS_BCJ-BJ-39">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="1380" y="137.6" width="210" height="32.54" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;i&gt;assertionMethod&lt;/i&gt;" link="https://w3id.org/security#assertionMethod" id="Uf8WLKuzS3drS_BCJ-BJ-40">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="1380" y="185.45" width="210" height="32.54" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;i&gt;capabilityDelegationMethod&lt;/i&gt;" link="https://w3id.org/security#capabilityDelegationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-41">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="1380" y="233.3" width="210" height="32.54" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;i&gt;capabilityInvocationMethod&lt;br&gt;&lt;/i&gt;" link="https://w3id.org/security#capabilityInvocationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-42">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="1380" y="281.15" width="210" height="32.54" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;i&gt;keyAgreementMethod&lt;/i&gt;" link="https://w3id.org/security#keyAgreementMethod" id="Uf8WLKuzS3drS_BCJ-BJ-43">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="1380" y="329" width="210" height="32.54" as="geometry" />
-          </mxCell>
-        </UserObject>
         <UserObject label="multibase" link="https://w3id.org/security#cryptosuiteString" id="aMvtbWUda6Bs1y7FLRK9-2">
           <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="710.1783123425694" y="652.0213235294117" width="149.3690176322418" height="28.708676470588237" as="geometry" />
@@ -452,7 +357,7 @@
           </mxCell>
         </UserObject>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-72" value="" style="group" parent="1" vertex="1" connectable="0">
-          <mxGeometry x="851.9997607052896" y="548.5666029411765" width="343.7402392947103" height="32.5365" as="geometry" />
+          <mxGeometry x="851.9997607052896" y="559.1966029411765" width="343.7402392947103" height="32.5365" as="geometry" />
         </mxCell>
         <UserObject label="&lt;i&gt;publicKeyMultibase&lt;/i&gt;" link="https://w3id.org/security#publicKeyMultibase" id="Uf8WLKuzS3drS_BCJ-BJ-60">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-72" vertex="1">
@@ -483,11 +388,11 @@
         </UserObject>
         <UserObject label="rdf:JSON" id="Uf8WLKuzS3drS_BCJ-BJ-64">
           <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="1335.93032115869" y="641.3913235294118" width="149.3690176322418" height="28.70867647058824" as="geometry" />
+            <mxGeometry x="1335.93032115869" y="652.0213235294117" width="149.3690176322418" height="28.70867647058824" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="Uf8WLKuzS3drS_BCJ-BJ-65" value="" style="group" parent="1" vertex="1" connectable="0">
-          <mxGeometry x="1232.9997481108312" y="548.5666029411765" width="355.2301637279597" height="32.536500000000004" as="geometry" />
+          <mxGeometry x="1232.9997481108312" y="559.1966029411765" width="355.2301637279597" height="32.536500000000004" as="geometry" />
         </mxCell>
         <UserObject label="&lt;i&gt;secretKeyJwk&lt;/i&gt;" link="https://w3id.org/security#secretKeyJwk" id="Uf8WLKuzS3drS_BCJ-BJ-62">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="Uf8WLKuzS3drS_BCJ-BJ-65" vertex="1">
@@ -543,7 +448,7 @@
         </mxCell>
         <UserObject label="&lt;i&gt;digestMultibase&lt;/i&gt;" link="https://w3id.org/security#digestMultibase" id="0YF8A2KC1bUMDjYDby_S-1">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="546.4489294710328" y="559.1980882352941" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+            <mxGeometry x="546.4489294710328" y="559.1966029411765" width="163.7314231738035" height="32.536500000000004" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="0YF8A2KC1bUMDjYDby_S-2" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;edgeStyle=orthogonalEdgeStyle;curved=1;" parent="1" source="0YF8A2KC1bUMDjYDby_S-1" target="aMvtbWUda6Bs1y7FLRK9-2" edge="1">
@@ -557,8 +462,174 @@
             <mxPoint x="915.74" y="281.15" as="sourcePoint" />
             <mxPoint x="1018.74" y="15.150000000000006" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="1098" y="160" />
+              <mxPoint x="1110" y="170" />
             </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;VerificationRelationship&lt;/i&gt;" link="https://w3id.org/security#VerificationRelationship" id="lNdu0edYDnSajEhI0VVL-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="669.7970717884131" y="-400" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-4" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=1;entryDx=0;entryDy=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-10" target="lNdu0edYDnSajEhI0VVL-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1710" y="-100" as="sourcePoint" />
+            <mxPoint x="1450" y="-15" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-6" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-9" target="Uf8WLKuzS3drS_BCJ-BJ-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="750" y="-140" as="sourcePoint" />
+            <mxPoint x="490" y="-55" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="570" y="60" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-9" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#006601;dashed=1;strokeWidth=2;dashPattern=1 4;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-38" target="lNdu0edYDnSajEhI0VVL-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1940" y="404" as="sourcePoint" />
+            <mxPoint x="1680" y="489" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-10" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;strokeColor=#006601;dashed=1;strokeWidth=2;dashPattern=1 4;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-39" target="lNdu0edYDnSajEhI0VVL-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1600" y="150" as="sourcePoint" />
+            <mxPoint x="1924" y="87" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-11" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#006601;dashed=1;strokeWidth=2;dashPattern=1 4;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-40" target="lNdu0edYDnSajEhI0VVL-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1610" y="126" as="sourcePoint" />
+            <mxPoint x="1934" y="97" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-12" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#006601;dashed=1;strokeWidth=2;dashPattern=1 4;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-41" target="lNdu0edYDnSajEhI0VVL-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1620" y="136" as="sourcePoint" />
+            <mxPoint x="1944" y="107" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-13" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#006601;dashed=1;strokeWidth=2;dashPattern=1 4;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-42" target="lNdu0edYDnSajEhI0VVL-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1630" y="146" as="sourcePoint" />
+            <mxPoint x="1954" y="117" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lNdu0edYDnSajEhI0VVL-14" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#006601;dashed=1;strokeWidth=2;dashPattern=1 4;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-43" target="lNdu0edYDnSajEhI0VVL-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1640" y="156" as="sourcePoint" />
+            <mxPoint x="1964" y="127" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0IjuMSqVGh2S3PIIxEyC-2" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="1104.034949622166" y="-320" width="210" height="271.78000000000003" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;verificationMethod&lt;/i&gt;" link="https://w3id.org/security#verificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-38">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="0IjuMSqVGh2S3PIIxEyC-2" vertex="1">
+            <mxGeometry width="210" height="32.54" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;authentication&lt;/i&gt;" link="https://w3id.org/security#authentication" id="Uf8WLKuzS3drS_BCJ-BJ-39">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="0IjuMSqVGh2S3PIIxEyC-2" vertex="1">
+            <mxGeometry y="47.84000000000003" width="210" height="32.54" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;assertionMethod&lt;/i&gt;" link="https://w3id.org/security#assertionMethod" id="Uf8WLKuzS3drS_BCJ-BJ-40">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="0IjuMSqVGh2S3PIIxEyC-2" vertex="1">
+            <mxGeometry y="95.69" width="210" height="32.54" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;capabilityDelegationMethod&lt;/i&gt;" link="https://w3id.org/security#capabilityDelegationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-41">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="0IjuMSqVGh2S3PIIxEyC-2" vertex="1">
+            <mxGeometry y="143.54000000000002" width="210" height="32.54" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;capabilityInvocationMethod&lt;br&gt;&lt;/i&gt;" link="https://w3id.org/security#capabilityInvocationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-42">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="0IjuMSqVGh2S3PIIxEyC-2" vertex="1">
+            <mxGeometry y="191.39" width="210" height="32.54" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;keyAgreementMethod&lt;/i&gt;" link="https://w3id.org/security#keyAgreementMethod" id="Uf8WLKuzS3drS_BCJ-BJ-43">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="0IjuMSqVGh2S3PIIxEyC-2" vertex="1">
+            <mxGeometry y="239.24" width="210" height="32.54" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="0IjuMSqVGh2S3PIIxEyC-3" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-43" target="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1600" y="70" as="sourcePoint" />
+            <mxPoint x="1340" y="144" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1370" y="20" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0IjuMSqVGh2S3PIIxEyC-4" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-42" target="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1383.11" y="-48.22" as="sourcePoint" />
+            <mxPoint x="1382.11" y="68.78" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1410" y="20" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0IjuMSqVGh2S3PIIxEyC-5" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-41" target="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1371" y="-133.92000000000002" as="sourcePoint" />
+            <mxPoint x="1370" y="31.08" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1460" y="10" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0IjuMSqVGh2S3PIIxEyC-6" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-40" target="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1381" y="-166.46" as="sourcePoint" />
+            <mxPoint x="1380" y="46.54" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1510" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0IjuMSqVGh2S3PIIxEyC-7" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-39" target="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1334" y="-140" as="sourcePoint" />
+            <mxPoint x="1333" y="73" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1430" y="-160" />
+              <mxPoint x="1470" y="10" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0IjuMSqVGh2S3PIIxEyC-8" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-38" target="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1324" y="-300" as="sourcePoint" />
+            <mxPoint x="1323" y="63" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="1490" y="-170" />
+              <mxPoint x="1490" y="20" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;VerificationMethod&lt;/i&gt;" link="https://w3id.org/security#VerificationMethod" id="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="1104.668136020151" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;Proof&lt;/i&gt;" link="https://w3id.org/security#Proof" id="Uf8WLKuzS3drS_BCJ-BJ-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;pointer-events=&quot;all&quot;" parent="1" vertex="1">
+            <mxGeometry x="234.92600755667502" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;verificationMethod&lt;/i&gt;" link="https://w3id.org/security#verificationMethod" id="0IjuMSqVGh2S3PIIxEyC-11">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+            <mxGeometry x="779.9989294710327" y="37.18000000000001" width="163.7314231738035" height="32.536500000000004" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="0IjuMSqVGh2S3PIIxEyC-12" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="0IjuMSqVGh2S3PIIxEyC-11" target="Uf8WLKuzS3drS_BCJ-BJ-37">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="1070" y="89.97000000000003" as="sourcePoint" />
+            <mxPoint x="810" y="163.97000000000003" as="targetPoint" />
           </mxGeometry>
         </mxCell>
       </root>

--- a/vocab/security/vocabulary.svg
+++ b/vocab/security/vocabulary.svg
@@ -1,11 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1624 879">
-    <rect width="1330" height="54.5" x="140" y="803.5" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all"/>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m1374 830.25 63.26.19" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1444.76 830.46-10.01 4.97 2.51-4.99-2.48-5.01Z" pointer-events="all"/>
-    <rect width="70" height="40" x="1290" y="804.75" fill="none" pointer-events="all"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-0.5 -0.5 1623 1309">
+    <rect width="1453" height="54.5" x="57.16" y="1233.5" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all"/>
+    <g fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path stroke-dasharray="2 8" d="m1411.16 1260.25 63.27.19" pointer-events="stroke"/>
+        <path d="m1481.93 1260.46-10.02 4.97 2.52-4.99-2.49-5.01Z" pointer-events="all"/>
+    </g>
+    <rect width="70" height="40" x="1327.16" y="1234.75" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:68px;height:1px;padding-top:812px;margin-left:1291px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:68px;height:1px;padding-top:1242px;margin-left:1328px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
@@ -15,13 +17,13 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="1325" y="828" font-family="Helvetica" font-size="16" text-anchor="middle">Graph con...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="1362" y="1258" font-family="Helvetica" font-size="16" text-anchor="middle">Graph con...</text>
     </switch>
-    <ellipse cx="261.5" cy="831.14" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
-    <rect width="50" height="30" x="151.5" y="812.19" fill="none" pointer-events="all"/>
+    <ellipse cx="178.66" cy="1261.14" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
+    <rect width="50" height="30" x="68.66" y="1242.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:177px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1257px;margin-left:94px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Class
@@ -29,13 +31,13 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="177" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="94" y="1261" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
     </switch>
-    <rect width="80" height="23.69" x="422" y="817.14" fill="none" stroke="#300" stroke-width="2" pointer-events="all" rx="3.55" ry="3.55"/>
-    <rect width="70" height="30" x="339" y="812.19" fill="none" pointer-events="all"/>
+    <rect width="80" height="23.69" x="328.16" y="1247.14" fill="none" stroke="#300" stroke-width="2" pointer-events="all" rx="3.55" ry="3.55"/>
+    <rect width="70" height="30" x="245.16" y="1242.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:374px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1257px;margin-left:280px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Property
@@ -43,14 +45,16 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="374" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="280" y="1261" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m810 830.13 71.76.56" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m887.76 830.73-8.03 3.94 2.03-3.98-1.96-4.02Z" pointer-events="all"/>
-    <rect width="80" height="30" x="718" y="812.19" fill="none" pointer-events="all"/>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="m696.16 1260.13 71.77.56" pointer-events="stroke"/>
+        <path d="m773.93 1260.73-8.03 3.94 2.03-3.98-1.97-4.02Z" pointer-events="all"/>
+    </g>
+    <rect width="80" height="30" x="604.16" y="1242.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:758px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1257px;margin-left:644px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Superclass
@@ -58,14 +62,16 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="758" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Superclass</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="644" y="1261" font-family="Helvetica" font-size="12" text-anchor="middle">Superclass</text>
     </switch>
-    <path fill="none" stroke="#f33" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1007 830.75 56 .05 15.76-.03" pointer-events="stroke"/>
-    <path fill="#f33" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m1084.76 830.75-7.99 4.02 1.99-4-2-4Z" pointer-events="all"/>
-    <rect width="60" height="30" x="933" y="812.19" fill="none" pointer-events="all"/>
+    <g stroke="#f33" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="m882.16 1260.75 56.04.05 15.73-.03" pointer-events="stroke"/>
+        <path fill="#f33" d="m959.93 1260.75-7.99 4.02 1.99-4-2.01-4Z" pointer-events="all"/>
+    </g>
+    <rect width="60" height="30" x="808.16" y="1242.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:963px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1257px;margin-left:838px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Domain
@@ -73,14 +79,16 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="963" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Domain</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="838" y="1261" font-family="Helvetica" font-size="12" text-anchor="middle">Domain</text>
     </switch>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1180 830.75h71.76" pointer-events="stroke"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1257.76 830.75-8 4 2-4-2-4Z" pointer-events="all"/>
-    <rect width="60" height="30" x="1113" y="812.19" fill="none" pointer-events="all"/>
+    <g stroke="#00c" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1045.16 1260.75h71.77" pointer-events="stroke"/>
+        <path fill="#00c" d="m1122.93 1260.75-8 4 2-4-2-4Z" pointer-events="all"/>
+    </g>
+    <rect width="60" height="30" x="978.16" y="1242.19" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:1143px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1257px;margin-left:1008px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Range
@@ -88,13 +96,13 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="1143" y="831" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="1008" y="1261" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M629 822.25h48.4l20 8.5-20 8.5H629l-20-8.5Z" pointer-events="all"/>
-    <rect width="90" height="40" x="534" y="810.75" fill="none" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M526.16 1252.25h48.4l20 8.5-20 8.5h-48.4l-20-8.5Z" pointer-events="all"/>
+    <rect width="90" height="40" x="431.16" y="1240.75" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:88px;height:1px;padding-top:818px;margin-left:536px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:88px;height:1px;padding-top:1248px;margin-left:433px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:center;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
@@ -104,30 +112,30 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="536" y="834" font-family="Helvetica" font-size="16">Datatype</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="433" y="1264" font-family="Helvetica" font-size="16">Datatype</text>
     </switch>
-    <a xlink:href="https://w3id.org/security#VerificationMethod">
-        <ellipse cx="1222.03" cy="44.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:44px;margin-left:1119px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                            <i>
-                                VerificationMethod
-                            </i>
-                        </div>
+    <g stroke="#006601" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 8" d="M1231.16 1264.31h71.77" pointer-events="stroke"/>
+        <path fill="#006601" d="m1308.93 1264.31-8 4 2-4-2-4Z" pointer-events="all"/>
+    </g>
+    <rect width="50" height="30" x="1169.16" y="1245.75" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1261px;margin-left:1194px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Type
                     </div>
                 </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1222" y="49" font-family="Helvetica" font-size="16" text-anchor="middle">VerificationMethod</text>
-        </switch>
-    </a>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1194" y="1264" font-family="Helvetica" font-size="12" text-anchor="middle">Type</text>
+    </switch>
     <a xlink:href="https://w3id.org/security#controller">
-        <rect width="163.73" height="32.54" x="881" y="290" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="881" y="720" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:306px;margin-left:882px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:736px;margin-left:882px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -137,14 +145,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="963" y="311" font-family="Helvetica" font-size="16" text-anchor="middle">controller</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="963" y="741" font-family="Helvetica" font-size="16" text-anchor="middle">controller</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#revoked">
-        <rect width="163.73" height="32.54" x="881" y="338.99" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="881" y="768.99" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:355px;margin-left:882px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:785px;margin-left:882px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -154,30 +162,22 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="963" y="360" font-family="Helvetica" font-size="16" text-anchor="middle">revoked</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="963" y="790" font-family="Helvetica" font-size="16" text-anchor="middle">revoked</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1393 97.03q-52-6.03-88.52-30.69" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1298.26 62.14 11.09 1.46-4.87 2.74-.73 5.54Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1393 144.87q-62-33.87-91.06-75.96" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.68 62.73 9.8 5.39-5.54.79-2.69 4.89Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1393 192.72Q1341 141 1301.14 69.4" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.5 62.85 9.23 6.3-5.59.25-3.15 4.62Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1393 240.57Q1331 161 1299.59 70.1" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1297.14 63.01 7.99 7.82-5.54-.73-3.91 3.99Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1393 288.42q-72-97.42-94.78-217.96" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1296.82 63.09 6.77 8.9-5.37-1.53-4.45 3.39Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1393 336.27Q1311 221 1297.29 70.59" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1296.61 63.12 5.89 9.51-5.21-2.04-4.75 2.94Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M1049.42 297.73Q1141 131 1147.66 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1045.81 304.31.43-11.18 3.18 4.6 5.59.22Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M1049.93 347.03Q1161 171 1147.66 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1045.93 353.37 1.11-11.12 2.89 4.78 5.56.55Z" pointer-events="all"/>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M1049.68 727.88Q1148 561 1147.66 490.89" pointer-events="stroke"/>
+        <path fill="#c00" d="m1045.87 734.34.77-11.16 3.04 4.7 5.57.38Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M1049.93 777.03Q1161 601 1147.66 490.89" pointer-events="stroke"/>
+        <path fill="#c00" d="m1045.93 783.37 1.11-11.12 2.89 4.78 5.56.55Z" pointer-events="all"/>
+    </g>
     <a xlink:href="https://w3id.org/security#Ed25519VerificationKey2020">
-        <ellipse cx="1226.51" cy="404.44" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="113.84" ry="23.445"/>
+        <ellipse cx="1226.51" cy="834.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="113.84" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:226px;height:1px;padding-top:404px;margin-left:1114px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:226px;height:1px;padding-top:834px;margin-left:1114px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -187,37 +187,26 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1227" y="409" font-family="Helvetica" font-size="16" text-anchor="middle">Ed25519VerificationKey2020</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1227" y="839" font-family="Helvetica" font-size="16" text-anchor="middle">Ed25519VerificationKey2020</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1423.61 441Q1231 291 1222.43 77.62" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.12 70.13 5.4 9.79-5.09-2.3-4.9 2.7Z" pointer-events="all"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1226.51 381-4.34-303.37" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.07 70.13 5.14 9.92-5.04-2.42-4.96 2.57Z" pointer-events="all"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1036.87 441Q1222 281 1222.03 77.63" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1222.03 70.13 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security#Proof">
-        <ellipse cx="352.29" cy="44.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:44px;margin-left:249px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                            <i>
-                                Proof
-                            </i>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="352" y="49" font-family="Helvetica" font-size="16" text-anchor="middle">Proof</text>
-        </switch>
-    </a>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M1423.61 871Q1231 721 1222.43 507.62" pointer-events="stroke"/>
+        <path d="m1222.12 500.13 5.4 9.79-5.09-2.3-4.9 2.7Z" pointer-events="all"/>
+    </g>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="m1226.51 811-4.34-303.37" pointer-events="stroke"/>
+        <path d="m1222.07 500.13 5.14 9.92-5.04-2.42-4.96 2.57Z" pointer-events="all"/>
+    </g>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M1036.87 871Q1222 711 1222.03 507.63" pointer-events="stroke"/>
+        <path d="m1222.03 500.13 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    </g>
     <a xlink:href="https://w3id.org/security#ProofGraph">
-        <ellipse cx="179.94" cy="178.42" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="179.94" cy="608.42" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:178px;margin-left:77px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:608px;margin-left:77px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -227,16 +216,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="180" y="183" font-family="Helvetica" font-size="16" text-anchor="middle">ProofGraph</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="180" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">ProofGraph</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m179.94 154.97 90.96-87.33" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m276.31 62.44-3.75 10.53-1.66-5.33-5.27-1.88Z" pointer-events="all"/>
+    <g fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path stroke-dasharray="2 8" d="m179.94 584.97 90.96-87.33" pointer-events="stroke"/>
+        <path d="m276.31 492.44-3.75 10.53-1.66-5.33-5.27-1.88Z" pointer-events="all"/>
+    </g>
     <a xlink:href="https://w3id.org/security#proof">
-        <rect width="163.73" height="32.54" x="98.56" y="308.09" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="98.56" y="738.09" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:324px;margin-left:100px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:754px;margin-left:100px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -246,16 +237,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="180" y="329" font-family="Helvetica" font-size="16" text-anchor="middle">proof</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="180" y="759" font-family="Helvetica" font-size="16" text-anchor="middle">proof</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m180.42 308.09-.43-96.49" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m179.95 204.1 5.05 9.98-5.01-2.48-4.99 2.52Z" pointer-events="all"/>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="m180.42 738.09-.43-96.49" pointer-events="stroke"/>
+        <path fill="#009" d="m179.95 634.1 5.05 9.98-5.01-2.48-4.99 2.52Z" pointer-events="all"/>
+    </g>
     <a xlink:href="https://w3id.org/security#domain">
-        <rect width="163.73" height="32.54" x="568.35" y="134" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="631" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:150px;margin-left:569px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:647px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -265,14 +258,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="650" y="155" font-family="Helvetica" font-size="16" text-anchor="middle">domain</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="652" font-family="Helvetica" font-size="16" text-anchor="middle">domain</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#challenge">
-        <rect width="163.73" height="32.54" x="568.35" y="239" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="689" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:255px;margin-left:569px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:705px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -282,14 +275,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="650" y="260" font-family="Helvetica" font-size="16" text-anchor="middle">challenge</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="710" font-family="Helvetica" font-size="16" text-anchor="middle">challenge</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#previousProof">
-        <rect width="163.73" height="32.54" x="568.35" y="87.89" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="573.91" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:104px;margin-left:569px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:590px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -299,14 +292,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="650" y="109" font-family="Helvetica" font-size="16" text-anchor="middle">previousProof</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="595" font-family="Helvetica" font-size="16" text-anchor="middle">previousProof</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#proofPurpose">
-        <rect width="163.73" height="32.54" x="568.35" y="290.15" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="483" y="254.54" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:306px;margin-left:569px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:271px;margin-left:484px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -317,15 +310,15 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="650" y="311" font-family="Helvetica" font-size="16" text-anchor="middle">proofPurpose
+            <text xmlns="http://www.w3.org/2000/svg" x="565" y="276" font-family="Helvetica" font-size="16" text-anchor="middle">proofPurpose
 </text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#proofValue">
-        <rect width="163.73" height="32.54" x="568.35" y="431.3" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="861.3" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:448px;margin-left:569px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:878px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -335,14 +328,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="650" y="452" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="882" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#expiration">
-        <rect width="163.73" height="32.54" x="881" y="238" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="881" y="668" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:254px;margin-left:882px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:684px;margin-left:882px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -352,14 +345,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="963" y="259" font-family="Helvetica" font-size="16" text-anchor="middle">expiration</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="963" y="689" font-family="Helvetica" font-size="16" text-anchor="middle">expiration</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#nonce">
-        <rect width="163.73" height="32.54" x="568.35" y="338" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="746" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:354px;margin-left:569px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:762px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -369,14 +362,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="650" y="359" font-family="Helvetica" font-size="16" text-anchor="middle">nonce</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="767" font-family="Helvetica" font-size="16" text-anchor="middle">nonce</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#created">
-        <rect width="163.73" height="32.54" x="568.35" y="385" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="568.35" y="804" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:401px;margin-left:569px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:820px;margin-left:569px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -386,30 +379,46 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="650" y="406" font-family="Helvetica" font-size="16" text-anchor="middle">created</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="650" y="825" font-family="Helvetica" font-size="16" text-anchor="middle">created</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M559.67 145.86Q491 111 426.67 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m566.36 149.26-11.18-.07 4.49-3.33.03-5.59Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M562.89 247.21Q491 141 426.67 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m567.1 253.42-9.75-5.48 5.54-.73 2.74-4.88Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M558.97 101.55Q521 91 426.67 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m566.19 103.56-10.97 2.14 3.75-4.15-1.07-5.48Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M563.68 297.88Q506.45 193.25 426.67 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m567.28 304.46-9.19-6.38 5.59-.2 3.18-4.6Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M562.51 439.78Q421 251 426.67 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m567.01 445.78-10-5.01 5.5-.99 2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M871.31 253.29Q551 221 426.98 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m878.77 254.04-10.45 3.98 2.99-4.73-1.98-5.22Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M561 347.88Q461 261 426.67 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m566.66 352.8-10.83-2.78 5.17-2.14 1.39-5.41Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M561.55 394.3Q451 281 426.67 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="M566.79 399.67 556.23 396l5.32-1.7 1.83-5.28Z" pointer-events="all"/>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M561.81 640.05 426.67 490.89" pointer-events="stroke"/>
+        <path fill="#c00" d="m566.85 645.61-10.42-4.05 5.38-1.51 2.03-5.21Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M562.71 697.33Q473 571 426.67 490.89" pointer-events="stroke"/>
+        <path fill="#c00" d="m567.05 703.45-9.86-5.26 5.52-.86 2.63-4.93Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="m560.38 584.59-133.71-93.7" pointer-events="stroke"/>
+        <path fill="#c00" d="m566.52 588.9-11.06-1.65 4.92-2.66.82-5.53Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M560.16 295.6Q513 381 426.67 458" pointer-events="stroke"/>
+        <path fill="#c00" d="m563.78 289.03-.45 11.17-3.17-4.6-5.59-.23Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M562.51 869.78Q421 681 426.67 490.89" pointer-events="stroke"/>
+        <path fill="#c00" d="m567.01 875.78-10-5.01 5.5-.99 2.5-5Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M956.73 660.44Q803 471 426.67 458" pointer-events="stroke"/>
+        <path fill="#c00" d="m961.46 666.26-10.19-4.61 5.46-1.21 2.31-5.09Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M561.7 755.16Q483 671 426.67 490.89" pointer-events="stroke"/>
+        <path fill="#c00" d="m566.82 760.64-10.48-3.89 5.36-1.59 1.94-5.24Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M561.59 813.26Q463 711 426.67 490.89" pointer-events="stroke"/>
+        <path fill="#c00" d="m566.8 818.66-10.54-3.73 5.33-1.67 1.87-5.27Z" pointer-events="all"/>
+    </g>
     <a xlink:href="https://w3id.org/security#DataIntegrityProof">
-        <ellipse cx="352.29" cy="475.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="352.29" cy="905.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:475px;margin-left:249px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:905px;margin-left:249px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -419,14 +428,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="352" y="480" font-family="Helvetica" font-size="16" text-anchor="middle">DataIntegrityProof</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="352" y="910" font-family="Helvetica" font-size="16" text-anchor="middle">DataIntegrityProof</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#Ed25519Signature2020">
-        <ellipse cx="125.37" cy="475.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <ellipse cx="125.37" cy="905.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:475px;margin-left:22px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:905px;margin-left:22px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -436,18 +445,22 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="125" y="480" font-family="Helvetica" font-size="16" text-anchor="middle">Ed25519Signature2020</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="125" y="910" font-family="Helvetica" font-size="16" text-anchor="middle">Ed25519Signature2020</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M352.29 451.63v-374" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m352.29 70.13 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M194.25 457.35Q349.42 317.66 352.18 77.63" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m352.27 70.13 4.88 10.05-4.97-2.55-5.03 2.44Z" pointer-events="all"/>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M352.29 881.63v-374" pointer-events="stroke"/>
+        <path d="m352.29 500.13 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    </g>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M194.25 887.35q155.17-139.69 157.93-379.72" pointer-events="stroke"/>
+        <path d="m352.27 500.13 4.88 10.05-4.97-2.55-5.03 2.44Z" pointer-events="all"/>
+    </g>
     <a xlink:href="https://w3id.org/security#cryptosuite">
-        <rect width="163.73" height="32.54" x="270.91" y="550.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="163.73" height="32.54" x="270.91" y="980.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:566px;margin-left:272px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:996px;margin-left:272px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -457,14 +470,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="353" y="571" font-family="Helvetica" font-size="16" text-anchor="middle">cryptosuite</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="353" y="1001" font-family="Helvetica" font-size="16" text-anchor="middle">cryptosuite</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#cryptosuiteString">
-        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M297.61 643.02h109.37l20 14.36-20 14.35H297.61l-20-14.35Z" pointer-events="all"/>
+        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M297.61 1073.02h109.37l20 14.36-20 14.35H297.61l-20-14.35Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:657px;margin-left:279px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:1087px;margin-left:279px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             cryptosuiteString
@@ -472,20 +485,265 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="352" y="662" font-family="Helvetica" font-size="16" text-anchor="middle">cryptosuiteString</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="352" y="1092" font-family="Helvetica" font-size="16" text-anchor="middle">cryptosuiteString</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m352.68 540.46-.39-41.94" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m352.75 547.96-5.09-9.95 5.02 2.45 4.98-2.55Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m352.77 582.73-.4 50.56" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m352.31 640.79-4.92-10.04 4.98 2.54 5.02-2.46Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M732.08 104.16q9.92.04 9.92-29.86T466.4 44.44" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m458.9 44.45 9.99-5.01-2.49 5 2.5 5Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security#verificationMethod">
-        <rect width="210" height="32.54" x="1393" y="80.76" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="m352.68 970.46-.39-41.94" pointer-events="stroke"/>
+        <path fill="#c00" d="m352.75 977.96-5.09-9.95 5.02 2.45 4.98-2.55Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="m352.77 1012.73-.4 50.56" pointer-events="stroke"/>
+        <path fill="#009" d="m352.31 1070.79-4.92-10.04 4.98 2.54 5.02-2.46Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://w3id.org/security#cryptosuiteString">
+        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M743.18 1073.02h109.37l20 14.36-20 14.35H743.18l-20-14.35Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:97px;margin-left:1394px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:1087px;margin-left:724px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            multibase
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="798" y="1092" font-family="Helvetica" font-size="16" text-anchor="middle">multibase</text>
+        </switch>
+    </a>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M732.08 877.57q65.82.03 65.78 185.72" pointer-events="stroke"/>
+        <path fill="#009" d="m797.86 1070.79-4.99-10.01 4.99 2.51 5.01-2.5Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://w3id.org/security#Multikey">
+        <ellipse cx="1036.87" cy="894.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:894px;margin-left:934px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                Multikey
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1037" y="899" font-family="Helvetica" font-size="16" text-anchor="middle">Multikey</text>
+        </switch>
+    </a>
+    <rect width="343.74" height="32.54" x="865" y="980.2" fill="none"/>
+    <a xlink:href="https://w3id.org/security#publicKeyMultibase">
+        <rect width="163.73" height="32.54" x="1050.75" y="980.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:996px;margin-left:1052px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                publicKeyMultibase
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1133" y="1001" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyMultibase</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3id.org/security#secretKeyMultibase">
+        <rect width="163.73" height="32.54" x="860.21" y="980.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:996px;margin-left:861px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                secretKeyMultibase
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="942" y="1001" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyMultibase</text>
+        </switch>
+    </a>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="m950.21 974.85 86.66-56.96" pointer-events="stroke"/>
+        <path fill="#c00" d="m943.95 978.97 5.61-9.67.65 5.55 4.84 2.8Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="m1124.46 974.89-87.59-57" pointer-events="stroke"/>
+        <path fill="#c00" d="m1130.75 978.98-11.11-1.27 4.82-2.82.63-5.56Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://w3id.org/security#JsonWebKey">
+        <ellipse cx="1423.61" cy="894.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:894px;margin-left:1320px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                JsonWebKey
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1424" y="899" font-family="Helvetica" font-size="16" text-anchor="middle">JsonWebKey</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1368.93 1073.02h109.37l20 14.36-20 14.35h-109.37l-20-14.35Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:1087px;margin-left:1350px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        rdf:JSON
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1424" y="1092" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
+    </switch>
+    <rect width="355.23" height="32.54" x="1246" y="980.2" fill="none"/>
+    <a xlink:href="https://w3id.org/security#secretKeyJwk">
+        <rect width="163.73" height="32.54" x="1246" y="980.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:996px;margin-left:1247px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                secretKeyJwk
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1328" y="1001" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyJwk</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3id.org/security#publicKeyJwk">
+        <rect width="163.73" height="32.54" x="1437.5" y="980.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:996px;margin-left:1438px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                publicKeyJwk
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1519" y="1001" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyJwk</text>
+        </switch>
+    </a>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="m1336.03 974.89 87.58-57" pointer-events="stroke"/>
+        <path fill="#c00" d="m1329.74 978.98 5.65-9.65.64 5.56 4.82 2.82Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="m1511.2 974.89-87.59-57" pointer-events="stroke"/>
+        <path fill="#c00" d="m1517.49 978.98-11.11-1.27 4.82-2.82.64-5.56Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="m1327.87 1012.73 87.51 55.1" pointer-events="stroke"/>
+        <path fill="#009" d="m1421.72 1071.83-11.12-1.1 4.78-2.9.54-5.56Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="m1519.36 1012.73-87.51 55.1" pointer-events="stroke"/>
+        <path fill="#009" d="m1425.51 1071.83 5.8-9.56.54 5.56 4.78 2.9Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M942.08 1012.73Q931 1061 881.42 1083.37" pointer-events="stroke"/>
+        <path fill="#009" d="m874.59 1086.46 7.05-8.67-.22 5.58 4.34 3.53Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1132.62 1012.73q-71.62 58.27-250.37 73.8" pointer-events="stroke"/>
+        <path fill="#009" d="m874.77 1087.18 9.53-5.84-2.05 5.19 2.92 4.77Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://w3id.org/security#digestMultibase">
+        <rect width="163.73" height="32.54" x="559.45" y="980.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:996px;margin-left:560px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                digestMultibase
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="641" y="1001" font-family="Helvetica" font-size="16" text-anchor="middle">digestMultibase</text>
+        </switch>
+    </a>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M641.31 1012.73q-.01 74.67 72.13 74.65" pointer-events="stroke"/>
+        <path fill="#009" d="m720.94 1087.38-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <g stroke="#c00" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 2" d="M1050.99 676.81Q1123 591 1147.66 490.89" pointer-events="stroke"/>
+        <path fill="#c00" d="m1046.17 682.56 2.6-10.88 2.22 5.13 5.44 1.3Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://w3id.org/security#VerificationRelationship">
+        <ellipse cx="787.16" cy="44.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:44px;margin-left:684px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                VerificationRelationship
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="787" y="49" font-family="Helvetica" font-size="16" text-anchor="middle">VerificationRelationship</text>
+        </switch>
+    </a>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M564.86 254.54 706.88 68.63" pointer-events="stroke"/>
+        <path fill="#009" d="m711.43 62.67-2.09 10.98-2.46-5.02-5.49-1.05Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M650.21 573.91Q583 481 466.38 474.95" pointer-events="stroke"/>
+        <path fill="#009" d="m458.89 474.56 10.25-4.47-2.76 4.86 2.24 5.12Z" pointer-events="all"/>
+    </g>
+    <g stroke="#006601" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 8" d="M1117.03 117.27 871.05 62.99" pointer-events="stroke"/>
+        <path fill="#006601" d="m863.72 61.38 10.84-2.73-3.51 4.34 1.36 5.42Z" pointer-events="all"/>
+    </g>
+    <g stroke="#006601" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 8" d="M1117.03 165.11 870.55 64.57" pointer-events="stroke"/>
+        <path fill="#006601" d="m863.61 61.74 11.15-.85-4.21 3.68.43 5.57Z" pointer-events="all"/>
+    </g>
+    <g stroke="#006601" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 8" d="M1117.03 212.96 869.9 65.87" pointer-events="stroke"/>
+        <path fill="#006601" d="m863.46 62.04 11.15.82-4.71 3.01-.4 5.58Z" pointer-events="all"/>
+    </g>
+    <g stroke="#006601" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 8" d="M1117.03 260.81 869.21 66.89" pointer-events="stroke"/>
+        <path fill="#006601" d="m863.3 62.27 10.96 2.23-5.05 2.39-1.12 5.48Z" pointer-events="all"/>
+    </g>
+    <g stroke="#006601" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 8" d="M1117.03 308.66 868.53 67.67" pointer-events="stroke"/>
+        <path fill="#006601" d="m863.14 62.45 10.66 3.37-5.27 1.85-1.69 5.33Z" pointer-events="all"/>
+    </g>
+    <g stroke="#006601" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="2 8" d="M1117.03 356.51 867.9 68.26" pointer-events="stroke"/>
+        <path fill="#006601" d="m863 62.59 10.32 4.29-5.42 1.38-2.14 5.16Z" pointer-events="all"/>
+    </g>
+    <rect width="210" height="271.78" x="1117.03" y="101" fill="none"/>
+    <a xlink:href="https://w3id.org/security#verificationMethod">
+        <rect width="210" height="32.54" x="1117.03" y="101" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:117px;margin-left:1118px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -495,14 +753,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1498" y="102" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1222" y="122" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#authentication">
-        <rect width="210" height="32.54" x="1393" y="128.6" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="210" height="32.54" x="1117.03" y="148.84" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:145px;margin-left:1394px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:165px;margin-left:1118px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -512,14 +770,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1498" y="150" font-family="Helvetica" font-size="16" text-anchor="middle">authentication</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1222" y="170" font-family="Helvetica" font-size="16" text-anchor="middle">authentication</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#assertionMethod">
-        <rect width="210" height="32.54" x="1393" y="176.45" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="210" height="32.54" x="1117.03" y="196.69" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:193px;margin-left:1394px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:213px;margin-left:1118px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -529,14 +787,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1498" y="198" font-family="Helvetica" font-size="16" text-anchor="middle">assertionMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1222" y="218" font-family="Helvetica" font-size="16" text-anchor="middle">assertionMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#capabilityDelegationMethod">
-        <rect width="210" height="32.54" x="1393" y="224.3" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="210" height="32.54" x="1117.03" y="244.54" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:241px;margin-left:1394px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:261px;margin-left:1118px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -546,14 +804,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1498" y="245" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityDelegationMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1222" y="266" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityDelegationMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#capabilityInvocationMethod">
-        <rect width="210" height="32.54" x="1393" y="272.15" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="210" height="32.54" x="1117.03" y="292.39" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:288px;margin-left:1394px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:309px;margin-left:1118px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -564,15 +822,15 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1498" y="293" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityInvocationMethod
+            <text xmlns="http://www.w3.org/2000/svg" x="1222" y="313" font-family="Helvetica" font-size="16" text-anchor="middle">capabilityInvocationMethod
 </text>
         </switch>
     </a>
     <a xlink:href="https://w3id.org/security#keyAgreementMethod">
-        <rect width="210" height="32.54" x="1393" y="320" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+        <rect width="210" height="32.54" x="1117.03" y="340.24" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:336px;margin-left:1394px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:208px;height:1px;padding-top:357px;margin-left:1118px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -582,178 +840,86 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1498" y="341" font-family="Helvetica" font-size="16" text-anchor="middle">keyAgreementMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1222" y="361" font-family="Helvetica" font-size="16" text-anchor="middle">keyAgreementMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security#cryptosuiteString">
-        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M743.18 643.02h109.37l20 14.36-20 14.35H743.18l-20-14.35Z" pointer-events="all"/>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1327.03 356.51q55.97 84.49 7.75 112.98" pointer-events="stroke"/>
+        <path fill="#009" d="m1328.33 473.31 6.06-9.39.39 5.57 4.7 3.04Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1327.03 308.66Q1423 441 1335.6 471.26" pointer-events="stroke"/>
+        <path fill="#009" d="m1328.51 473.71 7.82-7.99-.73 5.54 4 3.91Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1327.03 260.81Q1473 431 1335.74 471.68" pointer-events="stroke"/>
+        <path fill="#009" d="m1328.55 473.81 8.16-7.64-.97 5.51 3.81 4.08Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1327.03 212.96Q1523 421 1335.8 471.89" pointer-events="stroke"/>
+        <path fill="#009" d="m1328.56 473.86 8.34-7.45-1.1 5.48 3.72 4.17Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1327.03 165.11Q1443 261 1463 346q20 85-127.22 125.84" pointer-events="stroke"/>
+        <path fill="#009" d="m1328.56 473.85 8.3-7.49-1.08 5.48 3.75 4.15Z" pointer-events="all"/>
+    </g>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M1327.03 117.27Q1503 251 1503 346t-167.03 126.63" pointer-events="stroke"/>
+        <path fill="#009" d="m1328.6 474.03 8.89-6.77-1.52 5.37 3.38 4.45Z" pointer-events="all"/>
+    </g>
+    <a xlink:href="https://w3id.org/security#VerificationMethod">
+        <ellipse cx="1222.03" cy="474.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:657px;margin-left:724px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                            multibase
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="798" y="662" font-family="Helvetica" font-size="16" text-anchor="middle">multibase</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M732.08 447.57q65.82.03 65.78 185.72" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m797.86 640.79-4.99-10.01 4.99 2.51 5.01-2.5Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security#Multikey">
-        <ellipse cx="1036.87" cy="464.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:464px;margin-left:934px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:474px;margin-left:1119px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                Multikey
+                                VerificationMethod
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1037" y="469" font-family="Helvetica" font-size="16" text-anchor="middle">Multikey</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1222" y="479" font-family="Helvetica" font-size="16" text-anchor="middle">VerificationMethod</text>
         </switch>
     </a>
-    <rect width="343.74" height="32.54" x="865" y="539.57" fill="none"/>
-    <a xlink:href="https://w3id.org/security#publicKeyMultibase">
-        <rect width="163.73" height="32.54" x="1050.75" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+    <a xlink:href="https://w3id.org/security#Proof">
+        <ellipse cx="352.29" cy="474.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:1052px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:474px;margin-left:249px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                publicKeyMultibase
+                                Proof
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1133" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyMultibase</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="352" y="479" font-family="Helvetica" font-size="16" text-anchor="middle">Proof</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security#secretKeyMultibase">
-        <rect width="163.73" height="32.54" x="860.21" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
+    <a xlink:href="https://w3id.org/security#verificationMethod">
+        <rect width="163.73" height="32.54" x="793" y="458.18" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:861px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:474px;margin-left:794px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                secretKeyMultibase
+                                verificationMethod
                             </i>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="942" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyMultibase</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="875" y="479" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m950.63 534.91 86.24-47.02" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m944.04 538.5 6.39-9.18.2 5.59 4.58 3.19Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1124.05 534.94-87.18-47.05" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1130.65 538.5-11.17-.34 4.57-3.22.18-5.58Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security#JsonWebKey">
-        <ellipse cx="1423.61" cy="464.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:464px;margin-left:1320px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                            <i>
-                                JsonWebKey
-                            </i>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1424" y="469" font-family="Helvetica" font-size="16" text-anchor="middle">JsonWebKey</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1368.93 632.39h109.37l20 14.36-20 14.35h-109.37l-20-14.35Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:647px;margin-left:1350px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        rdf:JSON
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="1424" y="652" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
-    </switch>
-    <rect width="355.23" height="32.54" x="1246" y="539.57" fill="none"/>
-    <a xlink:href="https://w3id.org/security#secretKeyJwk">
-        <rect width="163.73" height="32.54" x="1246" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:1247px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                            <i>
-                                secretKeyJwk
-                            </i>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1328" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">secretKeyJwk</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3id.org/security#publicKeyJwk">
-        <rect width="163.73" height="32.54" x="1437.5" y="539.57" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:556px;margin-left:1438px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                            <i>
-                                publicKeyJwk
-                            </i>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1519" y="561" font-family="Helvetica" font-size="16" text-anchor="middle">publicKeyJwk</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1336.43 534.94 87.18-47.05" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1329.83 538.5 6.43-9.14.17 5.58 4.58 3.22Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="m1510.8 534.94-87.19-47.05" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1517.4 538.5-11.18-.34 4.58-3.22.17-5.58Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1327.87 572.1 87.51 55.1" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1421.72 631.2-11.12-1.1 4.78-2.9.54-5.56Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1519.36 572.1-87.51 55.1" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1425.51 631.2 5.8-9.56.54 5.56 4.78 2.9Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M942.08 572.1Q931 631 881.42 653.37" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m874.59 656.46 7.05-8.67-.22 5.58 4.34 3.53Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1132.62 572.1Q1061 641 882.25 656.53" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m874.77 657.18 9.53-5.84-2.05 5.19 2.92 4.77Z" pointer-events="all"/>
-    <a xlink:href="https://w3id.org/security#digestMultibase">
-        <rect width="163.73" height="32.54" x="559.45" y="550.2" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.88" ry="4.88"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:162px;height:1px;padding-top:566px;margin-left:560px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                            <i>
-                                digestMultibase
-                            </i>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="641" y="571" font-family="Helvetica" font-size="16" text-anchor="middle">digestMultibase</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M641.31 582.73q-.01 74.67 72.13 74.65" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m720.94 657.38-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="2 2" stroke-miterlimit="10" stroke-width="2" d="M1049.99 246.07Q1111 151 1147.66 60.89" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1045.94 252.39 1.19-11.12 2.86 4.8 5.56.6Z" pointer-events="all"/>
+    <g stroke="#009" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" stroke-dasharray="6 6" d="M956.73 474.45h151.2" pointer-events="stroke"/>
+        <path fill="#009" d="m1115.43 474.45-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
 </svg>

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -34,7 +34,7 @@ class:
     defined_by: https://www.w3.org/TR/vc-data-integrity/#verification-methods
 
   - id: VerificationRelationship
-    comment: Instances of this class are verification relationships like, for example, <a href="#authentication">authentication</a> or <a href="#assertionMethod">assertionMethod</a>. These resources can also appear as the values of the <a href="#proofPurpose">proofPurpose</a> property.
+    comment: Instances of this class are verification relationships like, for example, <a href="#authentication">authentication</a> or <a href="#assertionMethod">assertionMethod</a>. These resources can also appear as values of the <a href="#proofPurpose">proofPurpose</a> property.
     defined_by: https://www.w3.org/TR/vc-data-integrity/#verification-relationships
     upper_value: rdf:Property
     context: none

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -33,6 +33,12 @@ class:
     label: Verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#verification-methods
 
+  - id: VerificationRelationship
+    comment: Instances of this class are verification relationships like, for example, <a href="#authentication">authentication</a> or <a href="#assertionMethod">assertionMethod</a>. These resources can also appear as the values of the <a href="#proofPurpose">proofPurpose</a> property.
+    defined_by: https://www.w3.org/TR/vc-data-integrity/#verification-relationships
+    upper_value: rdf:Property
+    context: none
+
   - id: DataIntegrityProof
     label: A Data Integrity Proof
     upper_value: sec:Proof
@@ -219,7 +225,7 @@ property:
   - id: proofPurpose
     label: Proof purpose
     domain: sec:Proof
-    range: xsd:string
+    range: sec:VerificationRelationship
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-proofpurpose
     context: [vocab, https://www.w3.org/ns/credentials/v2]
 
@@ -256,18 +262,21 @@ property:
   - id: authentication
     label: Authentication method
     range: sec:VerificationMethod
+    type: sec:VerificationRelationship
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-authentication
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: assertionMethod
     label: Assertion method
     range: sec:VerificationMethod
+    type: sec:VerificationRelationship
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-assertionmethod
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: capabilityDelegationMethod
     label: Capability delegation method
     range: sec:VerificationMethod
+    type: sec:VerificationRelationship
     comment: Historically, this property has often been expressed using `capabilityDelegation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityDelegation`) and the property identifier (`...#capabilityDelegationMethod`) is expected and should not trigger an error.
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-capabilitydelegation
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
@@ -275,12 +284,14 @@ property:
   - id: capabilityInvocationMethod
     label: Capability invocation method
     range: sec:VerificationMethod
+    type: sec:VerificationRelationship
     comment: Historically, this property has often been expressed using `capabilityInvocation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityInvocation`) and the property identifier (`...#capabilityInvocationMethod`) is expected and should not trigger an error.
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-capabilityinvocation
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: keyAgreementMethod
     label: Key agreement protocols
+    type: sec:VerificationRelationship
     range: sec:VerificationMethod
     comment: Historically, this property has often been expressed using `keyAgreement` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`keyAgreement`) and the property identifier (`...#keyAgreementMethod`) is expected and should not trigger an error.
     defined_by: https://www.w3.org/TR/vc-data-integrity/#dfn-keyagreement
@@ -462,61 +473,61 @@ property:
 
 individual:
   - id: PROOF_GENERATION_ERROR
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Proof generation error
     defined_by: https://www.w3.org/TR/vc-data-integrity/#PROOF_GENERATION_ERROR
     context: none
 
   - id: MALFORMED_PROOF_ERROR
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Malformed proof
     defined_by: https://www.w3.org/TR/vc-data-integrity/#MALFORMED_PROOF_ERROR
     context: none
 
   - id: MISMATCHED_PROOF_PURPOSE_ERROR
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Mismatched proof purpose
     defined_by: https://www.w3.org/TR/vc-data-integrity/#MISMATCHED_PROOF_PURPOSE_ERROR
     context: none
 
   - id: INVALID_DOMAIN_ERROR
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Invalid proof domain
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_DOMAIN_ERROR
     context: none
 
   - id: INVALID_CHALLENGE_ERROR
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Invalid challenge
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CHALLENGE_ERROR
     context: none
 
   - id: INVALID_VERIFICATION_METHOD_URL
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Invalid verification method URL
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD_URL
     context: none
 
   - id: INVALID_CONTROLLER_DOCUMENT_ID
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Invalid controller document id
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CONTROLLER_DOCUMENT_ID
     context: none
 
   - id: INVALID_CONTROLLER_DOCUMENT
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Invalid controller document
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CONTROLLER_DOCUMENT
     context: none
 
   - id: INVALID_VERIFICATION_METHOD
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Invalid verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD
     context: none
 
   - id: INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD
-    upper_value: sec:ProcessingError
+    type: sec:ProcessingError
     label: Invalid proof purpose for verification method
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD
     context: none


### PR DESCRIPTION
The PR implements the solution for issue #248, as detailed in https://github.com/w3c/vc-data-integrity/issues/248#issuecomment-1999934991. This means changing the vocabulary, as well as the corresponding diagram.

As usual, the automatic preview is useless for vocabulary changes; instead, reviewers should use the [dedicated preview page](https://w3c.github.io/yml2vocab/previews/di/).

