### PR TITLE
Update proof set/chain verification algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3355,12 +3355,15 @@ references are also considered verified.
         <p>
 Required input is a
 [=secured data document=] (|securedDocument|). A list of
-verification results corresponding to each proof in |allProofs| is
-produced as output.
+[=verification result=]s corresponding to each proof in |allProofs| is
+generated, and a single boolean result is returned as output.
         </p>
         <ol class="algorithm">
           <li>
 Set |allProofs| to </var>|securedDocument|.|proof|.
+          </li>
+          <li>
+Set |verificationResults| to an empty list.
           </li>
           <li>
 For each |proof| in |allProofs|, do the following steps:
@@ -3383,24 +3386,29 @@ convey an error type of
               </li>
               <li>
 Let |unsecuredDocument| be a copy of |securedDocument| with the proof value
-removed and then set |unsecuredDocument.proof| to |matchingProofs|.
+removed and then set |unsecuredDocument|.|proof| to |matchingProofs|.
               </li>
               <li>
-Run steps 5 through 8 to validate the contents of |proof|.
-              </li>
-              <li>
-Run steps 10 through 15 of the algorithm in section [[[#verify-proof]]]; if no
-exceptions are raised, associate the |isProofVerified| value with this |proof|.
-                <p class="note">
-We specifically use the value of |unsecuredDocument| as set above, rather than
-using the value from step 5 of the algorithm in section [[[#verify-proof]]].
-                </p>
+Run steps 4 through 8 of the algorithm in section [[[#verify-proof]]] on
+|unsecuredDocument|; if no exceptions are raised, add |cryptosuiteVerificationResult|
+to |verificationResults|.
                 </li>
             </ol>
           </li>
           <li>
-Return the |allProofs| along with each proof's associated
-|isProofVerified| information.
+Let |combinedVerificationResult| be `true`.
+          </li>
+          <li>
+For each |cryptosuiteVerificationResult| in |verificationResults|:
+            <ol class="algorithm">
+              <li>
+If |cryptosuiteVerificationResult|.|verified| is `false`, set |combinedVerificationResult|
+to `false`.
+              </li>
+            </ol>
+          </li>
+          <li>
+Return |combinedVerificationResult|.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -3356,7 +3356,9 @@ references are also considered verified.
 Required input is a
 [=secured data document=] (|securedDocument|). A list of
 [=verification result=]s corresponding to each proof in |allProofs| is
-generated, and a single boolean result is returned as output.
+generated, and a single combined [=verification result=] is returned as output.
+Implementations MAY return any of the other [=verification result=]s or Any
+other metadata alongside the combined [=verification result=].
         </p>
         <ol class="algorithm">
           <li>
@@ -3396,16 +3398,28 @@ to |verificationResults|.
             </ol>
           </li>
           <li>
-Let |combinedVerificationResult| be `true`.
+Let |combinedVerificationResult| be an empty struct. Set |combinedVerificationResult|.|verified|
+to `true`, |combinedVerificationResult|.|verifiedDocument| to `null`, and 
+|combinedVerificationResult|.|mediaType| to `null`.
           </li>
           <li>
 For each |cryptosuiteVerificationResult| in |verificationResults|:
             <ol class="algorithm">
               <li>
-If |cryptosuiteVerificationResult|.|verified| is `false`, set |combinedVerificationResult|
+If |cryptosuiteVerificationResult|.|verified| is `false`, set |combinedVerificationResult|.|verified|
 to `false`.
               </li>
+              <li>
+Otherwise, set |combinedVerificationResult|.|verifiedDocument| to 
+|cryptosuiteVerificationResult|.|verifiedDocument|, and set
+|combinedVerificationResult|.|mediaType| to |cryptosuiteVerificationResult|.|mediaType|.
+              </li>
             </ol>
+          </li>
+          <li>
+If |combinedVerificationResult|.|verified| is `false`, set 
+|combinedVerificationResult|.|verifiedDocument| to `null` and 
+|combinedVerificationResult|.|mediaType| to `null`.
           </li>
           <li>
 Return |combinedVerificationResult|.

--- a/index.html
+++ b/index.html
@@ -3398,8 +3398,11 @@ to |verificationResults|.
             </ol>
           </li>
           <li>
-Let |combinedVerificationResult| be an empty struct. Set |combinedVerificationResult|.|verified|
-to `true`, |combinedVerificationResult|.|verifiedDocument| to `null`, and 
+Set |successfulVerificationResults| to an empty list.
+          </li>
+          <li>
+Let |combinedVerificationResult| be an empty struct. Set |combinedVerificationResult|.|status|
+to `true`, |combinedVerificationResult|.|document| to `null`, and 
 |combinedVerificationResult|.|mediaType| to `null`.
           </li>
           <li>
@@ -3410,19 +3413,20 @@ If |cryptosuiteVerificationResult|.|verified| is `false`, set |combinedVerificat
 to `false`.
               </li>
               <li>
-Otherwise, set |combinedVerificationResult|.|verifiedDocument| to 
-|cryptosuiteVerificationResult|.|verifiedDocument|, and set
-|combinedVerificationResult|.|mediaType| to |cryptosuiteVerificationResult|.|mediaType|.
+Otherwise, set |combinedVerificationResult|.|document| to 
+|cryptosuiteVerificationResult|.|verifiedDocument|, set
+|combinedVerificationResult|.|mediaType| to |cryptosuiteVerificationResult|.|mediaType|, and
+append |cryptosuiteVerificationResult| to |successfulVerificationResults|.
               </li>
             </ol>
           </li>
           <li>
-If |combinedVerificationResult|.|verified| is `false`, set 
-|combinedVerificationResult|.|verifiedDocument| to `null` and 
+If |combinedVerificationResult|.|status| is `false`, set 
+|combinedVerificationResult|.|document| to `null` and 
 |combinedVerificationResult|.|mediaType| to `null`.
           </li>
           <li>
-Return |combinedVerificationResult|.
+Return |combinedVerificationResult|, |successfulVerificationResults|.
           </li>
         </ol>
       </section>

--- a/index.html
+++ b/index.html
@@ -3355,9 +3355,9 @@ references are also considered verified.
         <p>
 Required input is a
 [=secured data document=] (|securedDocument|). A list of
-[=verification result=]s corresponding to each proof in |allProofs| is
+[=verification results=] corresponding to each proof in |allProofs| is
 generated, and a single combined [=verification result=] is returned as output.
-Implementations MAY return any of the other [=verification result=]s or Any
+Implementations MAY return any of the other [=verification result=]s and/or any
 other metadata alongside the combined [=verification result=].
         </p>
         <ol class="algorithm">
@@ -3392,7 +3392,7 @@ removed and then set |unsecuredDocument|.|proof| to |matchingProofs|.
               </li>
               <li>
 Run steps 4 through 8 of the algorithm in section [[[#verify-proof]]] on
-|unsecuredDocument|; if no exceptions are raised, add |cryptosuiteVerificationResult|
+|unsecuredDocument|; if no exceptions are raised, append |cryptosuiteVerificationResult|
 to |verificationResults|.
                 </li>
             </ol>


### PR DESCRIPTION
This PR attempts to fix #260 by doing the following things:

- fix outdated references to other algorithms
- change output format to conform with new interface


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/265.html" title="Last updated on Jun 5, 2024, 12:37 AM UTC (599f948)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/265/7de1987...599f948.html" title="Last updated on Jun 5, 2024, 12:37 AM UTC (599f948)">Diff</a>