### PR TITLE
Update proof section properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -784,9 +784,9 @@ which was to merely logging into a website.
 
           <dt>verificationMethod</dt>
           <dd>
-If included, `verificationMethod`, the means and information needed to verify the proof,
-MUST be specified as a string that maps to a [[URL]]. An example of a verification method
-is a link to a [=public key=] which includes cryptographic material that is used
+A verification method is the means and information needed to verify the proof.
+If included, the value MUST be a string that maps to a [[URL]]. An example of a 
+verification method is a link to a [=public key=] which includes cryptographic material that is used
 by a verifier during the verification process. Inclusion of `verificationMethod` is OPTIONAL, 
 but if it is not included, other properties such as `cryptosuite` MUST provide a mechanism
 by which to obtain the required information to verify the proof.
@@ -794,8 +794,10 @@ by which to obtain the required information to verify the proof.
 
           <dt>cryptosuite</dt>
           <dd>
-Information about the cryptographic suite that was used to generate the proof. See
-[[[#cryptographic-suites]]] for more information. `cryptosuite` is REQUIRED.
+An identifier for the cryptographic suite that can be used to verify the proof. See
+[[[#cryptographic-suites]]] for more information. If the proof type is
+`DataIntegrityProof`, `cryptosuite` MUST be specified; otherwise,  `cryptosuite`
+MAY be specified. If specified, its value MUST be a string.
           </dd>
 
           <dt><dfn class="lint-ignore">created</dfn></dt>
@@ -4533,7 +4535,7 @@ Narrowed date time values to use `dateTimeStamp`.
 Ensure that base URL is set to null when processing as RDF.
         </li>
         <li>
-Updated requirements for `proof` objects.
+Added requirement that `DataIntegrityProof` objects need to contain the `cryptosuite` property.
         </li>
       </ul>
     </section>

--- a/index.html
+++ b/index.html
@@ -4532,6 +4532,9 @@ Narrowed date time values to use `dateTimeStamp`.
         <li>
 Ensure that base URL is set to null when processing as RDF.
         </li>
+        <li>
+Updated requirements for `proof` objects.
+        </li>
       </ul>
     </section>
     <section class="appendix informative">

--- a/index.html
+++ b/index.html
@@ -785,11 +785,12 @@ which was to merely logging into a website.
           <dt>verificationMethod</dt>
           <dd>
 A verification method is the means and information needed to verify the proof.
-If included, the value MUST be a string that maps to a [[URL]]. An example of a 
-verification method is a link to a [=public key=] which includes cryptographic material that is used
-by a verifier during the verification process. Inclusion of `verificationMethod` is OPTIONAL, 
-but if it is not included, other properties such as `cryptosuite` MUST provide a mechanism
-by which to obtain the required information to verify the proof.
+If included, the value MUST be a string that maps to a [[URL]]. An example of a
+verification method is a link to a [=public key=] which includes cryptographic
+material that is used by a verifier during the verification process. Inclusion
+of `verificationMethod` is OPTIONAL, but if it is not included, other properties
+such as `cryptosuite` might provide a mechanism by which to obtain the required
+information to verify the proof.
           </dd>
 
           <dt>cryptosuite</dt>
@@ -1195,12 +1196,12 @@ The value of the `id` property for a [=verification method=] MUST be a
                 <dd>
 The value of the `type` property MUST be a [=string=] that either conforms to the
 [[URL]] syntax or maps (through interpretation of the `@context` property) to a [[URL]],
-and that references exactly one [=verification method=] type. 
+and that references exactly one [=verification method=] type.
 This specification defines two
 [=verification method=] types (<a href="#multikey">`Multikey`</a> and
 <a href="#jsonwebkey">`JsonWebKey`</a>); others might be defined by the community.
 To maximize global interoperability, such community-defined [=verification method=]
-types SHOULD be registered in the [[[VC-SPECS]]] [[[?VC-SPECS]]]. 
+types SHOULD be registered in the [[[VC-SPECS]]] [[[?VC-SPECS]]].
                 </dd>
                 <dt><span id="defn-controller">controller</span></dt>
                 <dd>
@@ -1363,7 +1364,7 @@ The value of the `type` property MUST contain the string `Multikey`.
               <dd>
 The `publicKeyMultibase` property is OPTIONAL. If present, its value MUST be a
 Multibase-encoded value as described in Section [[[#multibase-0]]]. The value format itself,
-which is encoded in Multibase, MUST be defined by the cryptographic suite specification used by 
+which is encoded in Multibase, MUST be defined by the cryptographic suite specification used by
 the [=verification method=].
               </dd>
               <dt><dfn class="lint-ignore">secretKeyMultibase</dfn></dt>
@@ -1376,8 +1377,8 @@ the [=verification method=].
             </dl>
 
             <p>
-              Implementations that perform JSON-LD processing MUST use the `https://w3id.org/security/multikey/v1` context URL for 
-              Multikey. 
+              Implementations that perform JSON-LD processing MUST use the `https://w3id.org/security/multikey/v1` context URL for
+              Multikey.
             </p>
 
             <p>

--- a/index.html
+++ b/index.html
@@ -784,10 +784,18 @@ which was to merely logging into a website.
 
           <dt>verificationMethod</dt>
           <dd>
-The means and information needed to verify the proof MUST be specified as a
-string that maps to a [[URL]]. An example of a verification method is a
-link to a [=public key=] which includes cryptographic material that is used
-by a verifier during the verification process.
+If included, `verificationMethod`, the means and information needed to verify the proof,
+MUST be specified as a string that maps to a [[URL]]. An example of a verification method
+is a link to a [=public key=] which includes cryptographic material that is used
+by a verifier during the verification process. Inclusion of `verificationMethod` is OPTIONAL, 
+but if it is not included, other properties such as `cryptosuite` MUST provide a mechanism
+by which to obtain the required information to verify the proof.
+          </dd>
+
+          <dt>cryptosuite</dt>
+          <dd>
+Information about the cryptographic suite that was used to generate the proof. See
+[[[#cryptographic-suites]]] for more information. `cryptosuite` is REQUIRED.
           </dd>
 
           <dt><dfn class="lint-ignore">created</dfn></dt>


### PR DESCRIPTION
This issue is an attempt to address PR #232 by doing the following things: 

- add `cryptosuite` as a required property of a proof.
- update discussion of `verificationMethod`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/266.html" title="Last updated on Jun 9, 2024, 3:47 PM UTC (15ff00b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/266/7de1987...15ff00b.html" title="Last updated on Jun 9, 2024, 3:47 PM UTC (15ff00b)">Diff</a>