### PR TITLE
Add type annotation to encoding/decoding examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2885,7 +2885,7 @@ Return |baseEncoding| as the base-encoded value.
 
         <pre class="example" title="An implementation of the general base-encoding algorithm above in Javascript">
 /**
-* @param {UInt8Array} bytes 
+* @param {Uint8Array} bytes 
 * @param {number} targetBase 
 * @param {string} baseAlphabet 
 * @returns string
@@ -3042,7 +3042,7 @@ to |decodedSize|, starting at offset |decodedOffset| to
 * @param {string} sourceEncoding
 * @param {number} sourceBase 
 * @param {string} baseAlphabet 
-* @returns UInt8Array
+* @returns Uint8Array
 */
 function baseDecode(sourceEncoding, sourceBase, baseAlphabet) {
   // build the base-alphabet to integer value map

--- a/index.html
+++ b/index.html
@@ -2884,6 +2884,12 @@ Return |baseEncoding| as the base-encoded value.
         </ol>
 
         <pre class="example" title="An implementation of the general base-encoding algorithm above in Javascript">
+/**
+* @param {UInt8Array} bytes 
+* @param {number} targetBase 
+* @param {string} baseAlphabet 
+* @returns string
+*/
 function baseEncode(bytes, targetBase, baseAlphabet) {
   let zeroes = 0;
   let length = 0;
@@ -3032,6 +3038,12 @@ to |decodedSize|, starting at offset |decodedOffset| to
         </ol>
 
         <pre class="example" title="An implementation of the general base-decoding algorithm above in Javascript">
+/**
+* @param {string} sourceEncoding
+* @param {number} sourceBase 
+* @param {string} baseAlphabet 
+* @returns UInt8Array
+*/
 function baseDecode(sourceEncoding, sourceBase, baseAlphabet) {
   // build the base-alphabet to integer value map
   baseMap = {};


### PR DESCRIPTION
This PR attempts to address issue #263 by adding type annotations to encoding/decoding examples.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/267.html" title="Last updated on Jun 5, 2024, 1:43 AM UTC (2f29a42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/267/7de1987...2f29a42.html" title="Last updated on Jun 5, 2024, 1:43 AM UTC (2f29a42)">Diff</a>