### PR TITLE
Explain difference between VM in proof and controller document.

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,10 +787,10 @@ which was to merely logging into a website.
 A verification method is the means and information needed to verify the proof.
 If included, the value MUST be a string that maps to a [[URL]]. Inclusion of
 `verificationMethod` is OPTIONAL, but if it is not included, other properties
-such as `cryptosuite` might provide a mechanism by which to obtain the required
-information to verify the proof. Note that when `verificationMethod` is
+such as `cryptosuite` might provide a mechanism by which to obtain the information
+necessary to verify the proof. Note that when `verificationMethod` is
 expressed in a [=data integrity proof=], the value points to the actual location
-of the data. That is, the `verificationMethod` references, via a URL, the
+of the data; that is, the `verificationMethod` references, via a URL, the
 location of the [=public key=] that can be used to verify the proof. This
 [=public key=] data is stored in a [=controller document=], which contains a
 full description of the verification method.
@@ -2100,9 +2100,12 @@ values.
         </p>
         <p>
 JSON-LD context authors are expected to add `digestMultibase` to contexts that will
-be used in documents that refer to other resources and include an associated
-content integrity hash. For example, the [[[VC-DATA-MODEL-2.0]]]
-context (`https://www.w3.org/ns/credentials/v2`) includes it.
+be used in documents that refer to other resources and to include an associated
+cryptographic digest. For example, the [[[VC-DATA-MODEL-2.0]]] refers to
+context (`https://www.w3.org/ns/credentials/v2`) which includes
+`digestMultibase`, and the [[[VC-DATA-MODEL-2.0]]] includes
+<data cite="VC-DATA-MODEL-2.0/#base-context">the hexadecimal encoded
+SHA2-256 digest value</data> of that context document.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -785,12 +785,15 @@ which was to merely logging into a website.
           <dt>verificationMethod</dt>
           <dd>
 A verification method is the means and information needed to verify the proof.
-If included, the value MUST be a string that maps to a [[URL]]. An example of a
-verification method is a link to a [=public key=] which includes cryptographic
-material that is used by a verifier during the verification process. Inclusion
-of `verificationMethod` is OPTIONAL, but if it is not included, other properties
+If included, the value MUST be a string that maps to a [[URL]]. Inclusion of
+`verificationMethod` is OPTIONAL, but if it is not included, other properties
 such as `cryptosuite` might provide a mechanism by which to obtain the required
-information to verify the proof.
+information to verify the proof. Note that when `verificationMethod` is
+expressed in a [=data integrity proof=], the value points to the actual location
+of the data. That is, the `verificationMethod` references, via a URL, the
+location of the [=public key=] that can be used to verify the proof. This
+[=public key=] data is stored in a [=controller document=], which contains a
+full description of the verification method.
           </dd>
 
           <dt>cryptosuite</dt>


### PR DESCRIPTION
This PR is an attempt to address issue #187 by explaining the difference between the `verificationMethod` property as it is used in a `proof` and the property as it is used in a controller document.

/cc @identitywoman


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/269.html" title="Last updated on Jun 27, 2024, 6:57 PM UTC (271d64f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/269/8afb5a8...271d64f.html" title="Last updated on Jun 27, 2024, 6:57 PM UTC (271d64f)">Diff</a>