### PR TITLE
Error code update and consolidation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3285,13 +3285,13 @@ If one or more of |proof|.|type|,
 |proof|.|verificationMethod|, and
 |proof|.|proofPurpose| does not [=map/exist=],
 an error MUST be raised and SHOULD convey an error type of
-<a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
+<a href="#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
           </li>
           <li>
 If |expectedProofPurpose| was given, and it does not match
 |proof|.|proofPurpose|,
 an error MUST be raised and SHOULD convey an error type of
-<a href="#MISMATCHED_PROOF_PURPOSE_ERROR">MISMATCHED_PROOF_PURPOSE_ERROR</a>.
+<a href="#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
           </li>
           <li>
 If |domain| was given, and it does not contain the same [=strings=] as
@@ -3365,13 +3365,13 @@ If |proof| contains a `previousProof` attribute and that attribute is a string,
 add the element from |allProofs| with an `id` attribute matching `previousProof`
 to `matchingProofs`. If a proof with `id` does not exist in |allProofs|, an
 error MUST be raised and SHOULD convey an error type of
-<a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>. If the
+<a href="#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>. If the
 `previousProof` attribute is an array, add each element from |allProofs| with an
 `id` attribute that matches an element of that array. If any element of
 `previousProof` array has an `id` attribute that does not match the `id`
 attribute of any element of |allProofs|, an error MUST be raised and SHOULD
 convey an error type of
-<a href="#MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR</a>.
+<a href="#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
               </li>
               <li>
 Let |unsecuredDocument| be a copy of |securedDocument| with the proof value
@@ -3556,14 +3556,13 @@ The `detail` value SHOULD provide a longer human-readable string for the error.
 A request to generate a proof failed. See Section [[[#add-proof]]], and Section
 [[[#add-proof-set-chain]]].
           </dd>
-          <dt id="MALFORMED_PROOF_ERROR">MALFORMED_PROOF_ERROR (-17)</dt>
+          <dt id="PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR (-17)</dt>
           <dd>
-A proof that is malformed was detected. See Section [[[#verify-proof]]].
+An error was encountered during proof verification. See Section [[[#verify-proof]]].
           </dd>
-          <dt id="MISMATCHED_PROOF_PURPOSE_ERROR">MISMATCHED_PROOF_PURPOSE_ERROR (-18)</dt>
+          <dt id="PROOF_TRANSFORMATION_ERROR ">PROOF_TRANSFORMATION_ERROR  (-18)</dt>
           <dd>
-The `proofPurpose` value in a proof did not match the expected value. See
-Section [[[#verify-proof]]].
+An error was encountered during the transformation process.
           </dd>
           <dt id="INVALID_DOMAIN_ERROR">INVALID_DOMAIN_ERROR (-19)</dt>
           <dd>


### PR DESCRIPTION
This PR is in response to issues https://github.com/w3c/vc-di-eddsa/issues/82, https://github.com/w3c/vc-di-ecdsa/issues/63, and https://github.com/w3c/vc-di-bbs/issues/168. It aims to unify error handling across cryptosuite specification by reusing a consistent set of error codes from this data integrity specification. It does this by making sure that there are general error code categories for three main classes of errors: (1) proof generation errors, (2) proof verification errors, and (3) proof transformation errors.

In particular this PR generalizes MALFORMED_PROOF_ERROR to PROOF_VERIFICATION_ERROR.; subsumes MISMATCHED_PROOF_PURPOSE_ERROR into PROOF_VERIFICATION_ERROR; and adds PROOF_TRANSFORMATION_ERROR.

Analysis of error codes from issue  https://github.com/w3c/vc-di-eddsa/issues/82:


## Error Codes in Data Integrity Spec and Suggestions

* **PROOF_GENERATION_ERROR** (-16): A request to generate a proof failed. See Section 4.3 Add Proof, and Section 4.4 Add Proof Set/Chain. *Notes*: This could subsume the INVALID_PROOF_CONFIGURATION, INVALID_PROOF_DATETIME errors from EdDSA, ECDSA, and BBS specs.
* **MALFORMED_PROOF_ERROR** (-17): A proof that is malformed was detected. See Section 4.5 Verify Proof. ==> **Propose** to change this to the more general **PROOF_VERIFICATION_ERROR**: An error was encountered during proof verification...
* *Propose* **PROOF_TRANSFORMATION_ERROR** (number TBA): An error was encountered during the transformation process. *Note*: transformation occurs during generation and verification of proofs. *Notes*: This is currently used in EdDSA and ECDSA specs.
* **MISMATCHED_PROOF_PURPOSE_ERROR** (-18): The proofPurpose value in a proof did not match the expected value. See Section 4.5 Verify Proof. ==> Propose to subsume this into *PROOF_VERIFICATION_ERROR*?

Would not change any of the following:

* **INVALID_DOMAIN_ERROR** (-19): The domain value in a proof did not match the expected value. See Section 4.5 Verify Proof.
* **INVALID_CHALLENGE_ERROR** (-20): The challenge value in a proof did not match the expected value. See Section 4.5 Verify Proof.
* **INVALID_VERIFICATION_METHOD_URL** (-21): The verificationMethod value in a proof was malformed. See Section 4.7 Retrieve Verification Method.
* **INVALID_CONTROLLER_DOCUMENT_ID** (-22): The id value in a controller document was malformed. See Section 4.7 Retrieve Verification Method.
* **INVALID_CONTROLLER_DOCUMENT** (-23): The controller document was malformed. See Section 4.7 Retrieve Verification Method.
* **INVALID_VERIFICATION_METHOD** (-24): The verification method in a controller document was malformed. See Section 4.7 Retrieve Verification Method.
* **INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD** (-25): The verification method in a controller document was not associated using the expected verification relationship as expressed in the proofPurpose property in the proof. See Section 4.7 Retrieve Verification Method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/274.html" title="Last updated on Jun 24, 2024, 4:56 PM UTC (ec528ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/274/8afb5a8...Wind4Greg:ec528ae.html" title="Last updated on Jun 24, 2024, 4:56 PM UTC (ec528ae)">Diff</a>