### PR TITLE
Use the right character type for a term

### DIFF
--- a/index.html
+++ b/index.html
@@ -1928,7 +1928,7 @@ raised and SHOULD convey an error type of
 <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
           </li>
           <li>
-Set |unsecuredDocument.proof| to |matchingProofs|.
+Set |unsecuredDocument|.|proof| to |matchingProofs|.
             <p class="note">
 This step is critical, as it <q>binds</q> the previous proofs to the document
 prior to signing. The |proof| value for the document will be updated


### PR DESCRIPTION
The "." character broke the effect of the '|' operator...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/285.html" title="Last updated on Jul 10, 2024, 12:36 PM UTC (04e1732)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/285/3ec2f9b...04e1732.html" title="Last updated on Jul 10, 2024, 12:36 PM UTC (04e1732)">Diff</a>