### PR TITLE
Fix contradicting statements about invalid proof time values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -783,7 +783,9 @@ as UTC.
 The `expires` property is OPTIONAL and, if present, specifies when the proof
 expires. If present, it MUST be an [[XMLSCHEMA11-2]] `dateTimeStamp` string,
 either in Universal Coordinated Time (UTC), denoted by a Z at the end of the
-value, or with a time zone offset relative to UTC.
+value, or with a time zone offset relative to UTC. If time values that
+were incorrectly serialized without an offset are accepted by a
+consumer, they are to be interpreted as UTC.
           </dd>
 
           <dt id="defn-domain">domain</dt>

--- a/index.html
+++ b/index.html
@@ -773,9 +773,9 @@ MAY be specified. If specified, its value MUST be a string.
 The date and time the proof was created is OPTIONAL and, if included, MUST be
 specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string, either in Universal
 Coordinated Time (UTC), denoted by a Z at the end of the value, or with a time
-zone offset relative to UTC. If time values that were incorrectly serialized
-without an offset are accepted by a consumer, they are to be interpreted
-as UTC.
+zone offset relative to UTC. A [=conforming processor=] MAY chose to consume
+time values that were incorrectly serialized without an offset. Incorrectly
+serialized time values without an offset are to be interpreted as UTC.
           </dd>
 
           <dt id="defn-proof-expires">expires</dt>

--- a/index.html
+++ b/index.html
@@ -783,9 +783,10 @@ serialized time values without an offset are to be interpreted as UTC.
 The `expires` property is OPTIONAL and, if present, specifies when the proof
 expires. If present, it MUST be an [[XMLSCHEMA11-2]] `dateTimeStamp` string,
 either in Universal Coordinated Time (UTC), denoted by a Z at the end of the
-value, or with a time zone offset relative to UTC. If time values that
-were incorrectly serialized without an offset are accepted by a
-consumer, they are to be interpreted as UTC.
+value, or with a time zone offset relative to UTC. A [=conforming processor=]
+MAY chose to consume time values that were incorrectly serialized without an
+offset. Incorrectly serialized time values without an offset are to be
+interpreted as UTC.
           </dd>
 
           <dt id="defn-domain">domain</dt>

--- a/index.html
+++ b/index.html
@@ -773,7 +773,9 @@ MAY be specified. If specified, its value MUST be a string.
 The date and time the proof was created is OPTIONAL and, if included, MUST be
 specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string, either in Universal
 Coordinated Time (UTC), denoted by a Z at the end of the value, or with a time
-zone offset relative to UTC.
+zone offset relative to UTC. If time values that were incorrectly serialized
+without an offset are accepted by a consumer, they are to be interpreted
+as UTC.
           </dd>
 
           <dt id="defn-proof-expires">expires</dt>

--- a/index.html
+++ b/index.html
@@ -773,8 +773,7 @@ MAY be specified. If specified, its value MUST be a string.
 The date and time the proof was created is OPTIONAL and, if included, MUST be
 specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string, either in Universal
 Coordinated Time (UTC), denoted by a Z at the end of the value, or with a time
-zone offset relative to UTC. Time values that are incorrectly serialized without
-an offset MUST be interpreted as UTC.
+zone offset relative to UTC.
           </dd>
 
           <dt id="defn-proof-expires">expires</dt>
@@ -782,8 +781,7 @@ an offset MUST be interpreted as UTC.
 The `expires` property is OPTIONAL and, if present, specifies when the proof
 expires. If present, it MUST be an [[XMLSCHEMA11-2]] `dateTimeStamp` string,
 either in Universal Coordinated Time (UTC), denoted by a Z at the end of the
-value, or with a time zone offset relative to UTC. Time values that are
-incorrectly serialized without an offset MUST be interpreted as UTC.
+value, or with a time zone offset relative to UTC.
           </dd>
 
           <dt id="defn-domain">domain</dt>


### PR DESCRIPTION
Addresses #294


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OpSecId/vc-data-integrity/pull/295.html" title="Last updated on Jul 28, 2024, 8:22 PM UTC (02e05c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/295/a065cfc...OpSecId:02e05c0.html" title="Last updated on Jul 28, 2024, 8:22 PM UTC (02e05c0)">Diff</a>