### PR TITLE
Disambiguate the proof chain creation and verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -1928,7 +1928,7 @@ raised and SHOULD convey an error type of
 <a href="#PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</a>.
           </li>
           <li>
-Set |unsecuredDocument|.|proof| to |matchingProofs|.
+Set |inputDocument|.|proof| to |matchingProofs|.
             <div class="note">
                 <p>
 This step adds references to the graph names, as well as adding a copy 

--- a/index.html
+++ b/index.html
@@ -2056,8 +2056,8 @@ This step adds references to the graph names, as well as adding a copy
 of <em>all</em> the claims contained in the proof graphs.
               </p>
               <p>
-The step is also critical, as it <q>binds</q> the previous proofs to the document
-prior to signing. The |proof| value for the document will be updated
+The step is critical, as it <q>binds</q> any matching proofs to the document prior
+to applying the current signature. The |proof| value for the document will be updated
 in a later step of this algorithm.
               </p>
             </div>

--- a/index.html
+++ b/index.html
@@ -2051,15 +2051,15 @@ raised and SHOULD convey an error type of
           <li>
 Set |inputDocument|.|proof| to |matchingProofs|.
             <div class="note">
-                <p>
+              <p>
 This step adds references to the graph names, as well as adding a copy 
 of <em>all</em> the claims contained in the proof graphs.
-                </p>
-                <p>
+              </p>
+              <p>
 The step is also critical, as it <q>binds</q> the previous proofs to the document
 prior to signing. The |proof| value for the document will be updated
 in a later step of this algorithm.
-                </p>
+              </p>
             </div>
           </li>
           <li>
@@ -2261,10 +2261,10 @@ convey an error type of
 Let |inputDocument| be a copy of |securedDocument| with the proof value
 removed and then set |inputDocument|.|proof| to |matchingProofs|.
 
-                        <p class="note">
+                <p class="note">
 See the note in <a href="#add-proof-set-chain"></a> to learn what
 claims this step entails.
-                        </p>
+                </p>
               </li>
               <li>
 Run steps 4 through 8 of the algorithm in section [[[#verify-proof]]] on

--- a/index.html
+++ b/index.html
@@ -1929,11 +1929,17 @@ raised and SHOULD convey an error type of
           </li>
           <li>
 Set |unsecuredDocument|.|proof| to |matchingProofs|.
-            <p class="note">
-This step is critical, as it <q>binds</q> the previous proofs to the document
+            <div class="note">
+                <p>
+This step means to add references to the graph names, as well as adding a copy 
+of <em>all</em> the claims contained in the proof graphs.
+                </p>
+                <p>
+The step is also critical, as it <q>binds</q> the previous proofs to the document
 prior to signing. The |proof| value for the document will be updated
 in a later step of this algorithm.
-            </p>
+                </p>
+            </div>
           </li>
           <li>
 Run steps 1 through 6 of the algorithm in section [[[#add-proof]]], passing
@@ -2133,6 +2139,11 @@ convey an error type of
               <li>
 Let |unsecuredDocument| be a copy of |securedDocument| with the proof value
 removed and then set |unsecuredDocument|.|proof| to |matchingProofs|.
+
+                        <p class="note">
+See also the note in <a href="#add-proof-set-chain"></a> on
+what this step entails in terms of claims.
+                        </p>
               </li>
               <li>
 Run steps 4 through 8 of the algorithm in section [[[#verify-proof]]] on

--- a/index.html
+++ b/index.html
@@ -1931,7 +1931,7 @@ raised and SHOULD convey an error type of
 Set |unsecuredDocument|.|proof| to |matchingProofs|.
             <div class="note">
                 <p>
-This step means to add references to the graph names, as well as adding a copy 
+This step adds references to the graph names, as well as adding a copy 
 of <em>all</em> the claims contained in the proof graphs.
                 </p>
                 <p>
@@ -2141,8 +2141,8 @@ Let |unsecuredDocument| be a copy of |securedDocument| with the proof value
 removed and then set |unsecuredDocument|.|proof| to |matchingProofs|.
 
                         <p class="note">
-See also the note in <a href="#add-proof-set-chain"></a> on
-what this step entails in terms of claims.
+See the note in <a href="#add-proof-set-chain"></a> to learn what
+claims this step entails.
                         </p>
               </li>
               <li>


### PR DESCRIPTION
This is to answer #289, inspired by the comment of @msporny in https://github.com/w3c/vc-data-integrity/issues/289#issuecomment-2241780121.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/296.html" title="Last updated on Aug 3, 2024, 9:13 PM UTC (866c266)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/296/a065cfc...866c266.html" title="Last updated on Aug 3, 2024, 9:13 PM UTC (866c266)">Diff</a>