### PR TITLE
Fix inconsistencies for consuming invalid time values.

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,8 +765,9 @@ MAY be specified. If specified, its value MUST be a string.
 The date and time the proof was created is OPTIONAL and, if included, MUST be
 specified as an [[XMLSCHEMA11-2]] `dateTimeStamp` string, either in Universal
 Coordinated Time (UTC), denoted by a Z at the end of the value, or with a time
-zone offset relative to UTC. Time values that are incorrectly serialized without
-an offset MUST be interpreted as UTC.
+zone offset relative to UTC. A [=conforming processor=] MAY chose to consume
+time values that were incorrectly serialized without an offset. Incorrectly
+serialized time values without an offset are to be interpreted as UTC.
           </dd>
 
           <dt id="defn-proof-expires">expires</dt>
@@ -774,8 +775,10 @@ an offset MUST be interpreted as UTC.
 The `expires` property is OPTIONAL and, if present, specifies when the proof
 expires. If present, it MUST be an [[XMLSCHEMA11-2]] `dateTimeStamp` string,
 either in Universal Coordinated Time (UTC), denoted by a Z at the end of the
-value, or with a time zone offset relative to UTC. Time values that are
-incorrectly serialized without an offset MUST be interpreted as UTC.
+value, or with a time zone offset relative to UTC. A [=conforming processor=]
+MAY chose to consume time values that were incorrectly serialized without an
+offset. Incorrectly serialized time values without an offset are to be
+interpreted as UTC.
           </dd>
 
           <dt id="defn-domain">domain</dt>


### PR DESCRIPTION
This PR is an attempt to address issue #294 by fixing inconsistencies on what constitutes a valid time value and what a conformant processor might do when consuming the value. /cc @PatStLouis


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/297.html" title="Last updated on Jul 27, 2024, 10:37 PM UTC (fa87520)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/297/a065cfc...fa87520.html" title="Last updated on Jul 27, 2024, 10:37 PM UTC (fa87520)">Diff</a>