### PR TITLE
Make `@context` injection optional.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1411,20 +1411,22 @@ as `DataIntegrityProof`, are used.
           </p>
 
           <p>
-When securing a document, if an `@context` property is not provided in the document
-or the Data Integrity terms used in the document are not mapped by
-existing values in the `@context` property, implementations MUST inject or add
-an `@context` property with a value of
-`https://w3id.org/security/data-integrity/v2`.
+When an application is securing a document, if an `@context` property is not
+provided in the document or the Data Integrity terms used in the document are
+not mapped by existing values in the `@context` property, implementations SHOULD
+inject or add a `@context` property with a value of
+`https://w3id.org/security/data-integrity/v2` or one or more contexts with at
+least the same declarations, such as the Verifiable Credential Data Model v2.0
+context (`https://www.w3.org/ns/credentials/v2`).
           </p>
 
           <p>
-Context injection is expected to be unnecessary sometimes, such as when the Verifiable
-Credential Data Model v2.0 context (`https://www.w3.org/ns/credentials/v2`)
-exists as a value in the `@context` property, as that context maps all of the
-necessary Data Integrity terms that were previously mapped by
-`https://w3id.org/security/data-integrity/v2`.
+Implementations that do no desire to use JSON-LD processing MAY choose to not
+include a `@context` declaration at the top-level of the document. If a
+`@context` declaration is not provided, extensions to this specification, or
+corresponding cryptosuites MUST NOT be made.
           </p>
+
         </section>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -1421,11 +1421,11 @@ context (`https://www.w3.org/ns/credentials/v2`).
           </p>
 
           <p>
-Implementations that do not desire to use JSON-LD processing MAY choose to not
-include a `@context` declaration at the top-level of the document. If a
-`@context` declaration is not provided, extensions (such as the addition of new
-properties) related to this specification or corresponding cryptosuites MUST NOT
-be made.
+Implementations that do not intend to use JSON-LD processing MAY choose to not
+include an `@context` declaration at the top-level of the document. However, if
+an `@context` declaration is not included, extensions (such as the addition of
+new properties) related to this specification or corresponding cryptosuites
+MUST NOT be made.
           </p>
 
         </section>

--- a/index.html
+++ b/index.html
@@ -1414,17 +1414,18 @@ as `DataIntegrityProof`, are used.
 When an application is securing a document, if an `@context` property is not
 provided in the document or the Data Integrity terms used in the document are
 not mapped by existing values in the `@context` property, implementations SHOULD
-inject or add a `@context` property with a value of
+inject or append an `@context` property with a value of
 `https://w3id.org/security/data-integrity/v2` or one or more contexts with at
 least the same declarations, such as the Verifiable Credential Data Model v2.0
 context (`https://www.w3.org/ns/credentials/v2`).
           </p>
 
           <p>
-Implementations that do no desire to use JSON-LD processing MAY choose to not
+Implementations that do not desire to use JSON-LD processing MAY choose to not
 include a `@context` declaration at the top-level of the document. If a
-`@context` declaration is not provided, extensions to this specification, or
-corresponding cryptosuites MUST NOT be made.
+`@context` declaration is not provided, extensions (such as the addition of new
+properties) related to this specification or corresponding cryptosuites MUST NOT
+be made.
           </p>
 
         </section>


### PR DESCRIPTION
This PR has been raised to address issue #281 by making context injection optional during the securing process. 

/cc @rflechtner @silverpill


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/301.html" title="Last updated on Aug 3, 2024, 9:21 PM UTC (17b1521)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/301/a065cfc...17b1521.html" title="Last updated on Aug 3, 2024, 9:21 PM UTC (17b1521)">Diff</a>