### PR TITLE
Removal of the multibase datatype section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1245,6 +1245,13 @@ Implementations that perform RDF processing MUST treat
 the JSON-LD serialization of the vocabulary URL as already dereferenced, where the dereferenced document matches
 the corresponding hash value below.
         </p>
+        
+        <p class="note">
+          Beyond the security terms defined by this specification, the
+          <a href="https://w3id.org/security">https://w3id.org/security#</a> namespace
+          also includes the terms defined in the [[[CONTROLLER-DOCUMENT]]] [[CONTROLLER-DOCUMENT]]
+          specification, with the corresponding mappings in the context files listed above.
+        </p>
 
         <p>
 When dereferencing the
@@ -1523,51 +1530,6 @@ other possible cryptosuite types.
             <dd>
 Any element of the value space is mapped to the corresponding string in the
 lexical space.
-            </dd>
-          </dl>
-        </section>
-
-        <section>
-          <h4 id="multibase">The `multibase` Datatype</h3>
-
-          <p>
-<a href="#multibase">Multibase</a>-encoded strings are used to encode binary
-data into ASCII-only formats, which are useful in environments that cannot
-directly represent binary values. This specification makes use of this encoding.
-In environments that support data types for string values, such as RDF
-[[?RDF-CONCEPTS]], <a href="#multibase">Multibase</a>-encoded content is
-indicated using a literal value whose datatype is set to
-`https://w3id.org/security#multibase`.
-          </p>
-
-          <p>
-The `multibase` datatype is defined as follows:
-          </p>
-
-          <dl>
-            <dt>The URL denoting this datatype</dt>
-            <dd>
-`https://w3id.org/security#multibase`
-            </dd>
-            <dt>The lexical space</dt>
-            <dd>
-Any string that starts with a <a href="#multibase">Multibase</a> character and
-the rest of the characters consist of allowable characters in the respective
-base-encoding alphabet.
-            </dd>
-            <dt>The value space</dt>
-            <dd>
-The standard mathematical concept of all integer numbers.
-            </dd>
-            <dt>The lexical-to-value mapping</dt>
-            <dd>
-Any element of the lexical space is mapped to the value space by base-decoding
-the value based on the base-decoding alphabet associated with the
-first <a href="#multibase">Multibase</a> character in the lexical string.
-            </dd>
-            <dt>The canonical mapping</dt>
-            <dd>
-The canonical mapping consists of using the lexical-to-value mapping.
             </dd>
           </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -1245,12 +1245,12 @@ Implementations that perform RDF processing MUST treat
 the JSON-LD serialization of the vocabulary URL as already dereferenced, where the dereferenced document matches
 the corresponding hash value below.
         </p>
-        
+
         <p class="note">
-          Beyond the security terms defined by this specification, the
-          <a href="https://w3id.org/security">https://w3id.org/security#</a> namespace
-          also includes the terms defined in the [[[CONTROLLER-DOCUMENT]]] [[CONTROLLER-DOCUMENT]]
-          specification, with the corresponding mappings in the context files listed above.
+Beyond the security terms defined by this specification, the
+<a href="https://w3id.org/security">https://w3id.org/security#</a> namespace
+also includes the terms defined in the [[[CONTROLLER-DOCUMENT]]] [[CONTROLLER-DOCUMENT]]
+specification, with the corresponding mappings in the context files listed above.
         </p>
 
         <p>

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -267,14 +267,14 @@ property:
     label: Authentication method
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
-    defined_by: https://www.w3.org/TR/controller-document/#defn-authentication
+    defined_by: https://www.w3.org/TR/controller-document/#authentication
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: assertionMethod
     label: Assertion method
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
-    defined_by: https://www.w3.org/TR/controller-document/#defn-assertionmethod
+    defined_by: https://www.w3.org/TR/controller-document/#assertion
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: capabilityDelegationMethod
@@ -282,7 +282,7 @@ property:
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
     comment: Historically, this property has often been expressed using `capabilityDelegation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityDelegation`) and the property identifier (`...#capabilityDelegationMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/controller-document/#defn-capabilityDelegation
+    defined_by: https://www.w3.org/TR/controller-document/#capability-delegation
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: capabilityInvocationMethod
@@ -290,7 +290,7 @@ property:
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
     comment: Historically, this property has often been expressed using `capabilityInvocation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityInvocation`) and the property identifier (`...#capabilityInvocationMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/controller-document/#defn-capabilityInvocation
+    defined_by: https://www.w3.org/TR/controller-document/#capability-invocation
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: keyAgreementMethod
@@ -298,7 +298,7 @@ property:
     type: sec:VerificationRelationship
     range: sec:VerificationMethod
     comment: Historically, this property has often been expressed using `keyAgreement` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`keyAgreement`) and the property identifier (`...#keyAgreementMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/controller-document/#defn-keyAgreement
+    defined_by: https://www.w3.org/TR/controller-document/#key-agreement
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: cryptosuite


### PR DESCRIPTION
When aligning with the controller specification, the section defining the multibase datatype was not removed. That datatype is now formally defined in the controller document (the formal vocabulary has already been changed).

Also, I have added a minor node making it clear that the context and vocabulary files, referred to in the section on contexts and vocabularies ([§ 2.4](https://www.w3.org/TR/vc-data-integrity/#contexts-and-vocabularies)) also includes terms defined in the controller document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/304.html" title="Last updated on Aug 20, 2024, 3:14 PM UTC (a0bc808)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/304/bd689f5...a0bc808.html" title="Last updated on Aug 20, 2024, 3:14 PM UTC (a0bc808)">Diff</a>