### PR TITLE
Convert issue on guidance on deprecated/experimental crypto.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2525,6 +2525,14 @@ experts to fine tune their use of the library, use of those options by the gener
 application developer population is to be discouraged.
           </li>
           <li>
+Cryptographic library implementers can provide deprecated and experimental
+cryptographic functionality, but are advised to do so in a way where the
+libraries do not enable such functionality unless explicitly requested by the
+developer, such as via a library option, and if enabled, the library produces
+warnings that deprecated or experimental cryptography has been enabled for the
+application.
+          </li>
+          <li>
 Application developers are advised to choose from a number of pre-set
 cryptography library configurations and to avoid modifying cryptographic
 options and parameters, or using experimental or deprecated cryptography.
@@ -2538,15 +2546,6 @@ exposing those options and parameters to application developers who may not
 fully understand the balancing benefits and drawbacks of each option.
         </p>
 
-        <p class="issue"
-          title="Use of experimental and deprecated cryptography">
-The VCWG is seeking guidance on adding language to allow the use of experimental
-or deprecated cryptography. By default, those features will be disabled and will
-require the application developer to specifically allow use on a per-cryptographic suite
-basis. There will be requirements for all implementing libraries to throw errors
-or warnings when deprecated or experimental options are selected without the
-appropriate override flags.
-        </p>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -2526,11 +2526,10 @@ application developer population is to be discouraged.
           </li>
           <li>
 Cryptographic library implementers can provide deprecated and experimental
-cryptographic functionality, but are advised to do so in a way where the
-libraries do not enable such functionality unless explicitly requested by the
-developer, such as via a library option, and if enabled, the library produces
-warnings that deprecated or experimental cryptography has been enabled for the
-application.
+cryptographic functionality, but are advised to only do so when explicitly
+requested by the developer, such as through a library option, and such that the
+library produces warnings that deprecated or experimental cryptography has
+been enabled for the application.
           </li>
           <li>
 Application developers are advised to choose from a number of pre-set


### PR DESCRIPTION
This PR converts an issue marker to concrete text regarding the use of deprecated and experimental cryptography in the Data Integrity specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/305.html" title="Last updated on Sep 16, 2024, 12:14 AM UTC (b02c4cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/305/4e35b80...b02c4cd.html" title="Last updated on Sep 16, 2024, 12:14 AM UTC (b02c4cd)">Diff</a>