### PR TITLE
Add sentence to previousProof

### DIFF
--- a/index.html
+++ b/index.html
@@ -824,11 +824,11 @@ to verify the digital proof.
 
           <dt><dfn class="lint-ignore">previousProof</dfn></dt>
           <dd>
-The previousProof property is OPTIONAL. If present, it MUST be a string 
-value or unordered list of string values. Each value identifies another 
-[=data integrity proof=] that MUST also verify in order for the current
-proof to be considered verified. This property is used in
-Section [[[#proof-chains]]].
+The `previousProof` property is OPTIONAL. If present, it MUST be a string
+value or an unordered list of string values. Each value identifies another
+[=data integrity proof=], all of which MUST also verify for the current
+proof to be considered verified. This property is used in Section
+[[[#proof-chains]]].
           </dd>
 
           <dt><dfn class="lint-ignore">nonce</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -827,8 +827,8 @@ to verify the digital proof.
 The previousProof property is OPTIONAL. If present, it MUST be a string 
 value or unordered list of string values. Each value identifies another 
 [=data integrity proof=] that MUST verify in order for the current
-proof to be considered verified. All referenced proofs in the array 
-MUST verify. This property is used in Section [[[#proof-chains]]].
+proof to be considered verified. This property is used in
+Section [[[#proof-chains]]].
           </dd>
 
           <dt><dfn class="lint-ignore">nonce</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -826,7 +826,7 @@ to verify the digital proof.
           <dd>
 The previousProof property is OPTIONAL. If present, it MUST be a string 
 value or unordered list of string values. Each value identifies another 
-[=data integrity proof=] that MUST verify in order for the current
+[=data integrity proof=] that MUST also verify in order for the current
 proof to be considered verified. This property is used in
 Section [[[#proof-chains]]].
           </dd>

--- a/index.html
+++ b/index.html
@@ -827,7 +827,7 @@ to verify the digital proof.
 The previousProof property is OPTIONAL. If present, it MUST be a string 
 value or unordered list of string values. Each value identifies another 
 [=data integrity proof=] that MUST verify before the current proof is 
-processed. If an unordered list, all referenced proofs in the array 
+processed. All referenced proofs in the array 
 MUST verify. This property is used in Section [[[#proof-chains]]].
           </dd>
 

--- a/index.html
+++ b/index.html
@@ -824,10 +824,11 @@ to verify the digital proof.
 
           <dt><dfn class="lint-ignore">previousProof</dfn></dt>
           <dd>
-An OPTIONAL string value or unordered list of string values. Each value
-identifies another [=data integrity proof=] that MUST verify before the
-current proof is processed. If an unordered list, all referenced proofs in the
-array MUST verify. This property is used in Section [[[#proof-chains]]].
+The previousProof property is OPTIONAL. If present, it MUST be a string 
+value or unordered list of string values. Each value identifies another 
+[=data integrity proof=] that MUST verify before the current proof is 
+processed. If an unordered list, all referenced proofs in the array 
+MUST verify. This property is used in Section [[[#proof-chains]]].
           </dd>
 
           <dt><dfn class="lint-ignore">nonce</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -826,8 +826,8 @@ to verify the digital proof.
           <dd>
 The previousProof property is OPTIONAL. If present, it MUST be a string 
 value or unordered list of string values. Each value identifies another 
-[=data integrity proof=] that MUST verify before the current proof is 
-processed. All referenced proofs in the array 
+[=data integrity proof=] that MUST verify in order for the current
+proof to be considered verified. All referenced proofs in the array 
 MUST verify. This property is used in Section [[[#proof-chains]]].
           </dd>
 


### PR DESCRIPTION
Suggestion from #307. This doesn't introduce any changes in the spec it just clarifies the property's usage.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/OpSecId/vc-data-integrity/pull/309.html" title="Last updated on Sep 6, 2024, 8:11 PM UTC (cfa36e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/309/1d7bfa6...OpSecId:cfa36e9.html" title="Last updated on Sep 6, 2024, 8:11 PM UTC (cfa36e9)">Diff</a>