### PR TITLE
Added an extra vocabulary definition reference for expiration

### DIFF
--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -248,7 +248,7 @@ property:
 
   - id: expiration
     label: Expiration time for a proof or verification method
-    defined_by: https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires
+    defined_by: [https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires, https://www.w3.org/TR/controller-document/#defn-vm-expires]
     comment: Historically, this property has often been expressed using `expires` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`expires`) and the property identifier (`...#expiration`) is expected and should not trigger an error.
     domain:
       - sec:Proof


### PR DESCRIPTION
This is a counterpart to https://github.com/w3c/controller-document/pull/96. Should only be merged when (1) that PR is merged ~and (2) when the latest (1.4.9) version of yml2vocab has been published on npm~.