### PR TITLE
rephrase previousProof paragraph in algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -2181,16 +2181,18 @@ For each |proof| in |allProofs|, do the following steps:
 Let |matchingProofs| be an empty list.
               </li>
               <li>
-If |proof| contains a `previousProof` attribute and that attribute is a
-[=string=], add the element from |allProofs| with an `id` attribute matching
-`previousProof` to `matchingProofs`. If a proof with `id` equal to `previousProof`
-does not exist in |allProofs|, an error MUST be raised and SHOULD convey an error type of
+If |proof| contains a `previousProof` attribute and the value of that
+attribute is a [=string=], add the element from |allProofs| with an `id`
+attribute value matching the value of `previousProof` to `matchingProofs`.
+If a proof with `id` value equal to the value of `previousProof` does not
+exist in |allProofs|, an error MUST be raised and SHOULD convey an error
+type of
 <a href="#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>. If the
-`previousProof` attribute is a [=list=], add each element from |allProofs| with an
-`id` attribute that matches an element of that [=list=]. If any element of
-`previousProof` [=list=] has an `id` attribute that does not match the `id`
-attribute of any element of |allProofs|, an error MUST be raised and SHOULD
-convey an error type of
+`previousProof` attribute is a [=list=], add each element from |allProofs|
+with an `id` attribute value that matches the value of an element of that
+[=list=]. If any element of `previousProof` [=list=] has an `id` attribute
+value that does not match the `id` attribute value of any element of
+|allProofs|, an error MUST be raised and SHOULD convey an error type of
 <a href="#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
               </li>
               <li>


### PR DESCRIPTION
GitHub seems to hate us. There *are* changes in lines 2184-2189, even though GitHub is not highlighting them. These changes are meant to make this paragraph internally consistent; hopefully the other paragraphs/steps are already consistent with the specificity I've applied here. If the others disagree, then either this one could be re-edited to match them, or the others could be edited to match what I've done here; I feel most strongly that they should agree with each other, and I feel that this degree of specificity is better.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/vc-data-integrity/pull/312.html" title="Last updated on Sep 16, 2024, 9:24 PM UTC (d8a3f2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/312/3af0e87...TallTed:d8a3f2d.html" title="Last updated on Sep 16, 2024, 9:24 PM UTC (d8a3f2d)">Diff</a>