### PR TITLE
Add expires example to proof.

### DIFF
--- a/index.html
+++ b/index.html
@@ -927,7 +927,7 @@ representing time values to individuals.
         </p>
 
         <pre class="example nohighlight"
-        title="A proof attached to a data document that uses the 'expires' property">
+        title="A data document with an attached proof that uses the 'expires' property">
 {
   "@context": [
     {"myWebsite": "https://vocabulary.example/myWebsite"},
@@ -938,8 +938,8 @@ representing time values to individuals.
     "type": "DataIntegrityProof",
     "cryptosuite": "ecdsa-rdfc-2019",
     "created": "2020-06-11T19:14:04Z",
-    <span class="comment">// the proof expires a month after it was issued</span>
-    <span class="highlight">expires": "2020-07-11T19:14:04Z"</span>,
+    <span class="comment">// the proof expires a month after it was created</span>
+    <span class="highlight">"expires": "2020-07-11T19:14:04Z"</span>,
     "verificationMethod": "https://ldi.example/issuer#zDnaepBuvsQ8cpsWrVK<wbr>w8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
     "proofPurpose": "assertionMethod",
     "proofValue": "z98X7RLrkjnXEADJNUhiTEdwyE5GXX8cyJZRLQZ7vZyUXb23Zkdakf<wbr>RJ7adYY8hn35EetqBkNw813SGsJHWrcpo4"

--- a/index.html
+++ b/index.html
@@ -926,6 +926,27 @@ expectations of the individual. See
 representing time values to individuals.
         </p>
 
+        <pre class="example nohighlight"
+        title="A proof attached to a data document that uses the 'expires' property">
+{
+  "@context": [
+    {"myWebsite": "https://vocabulary.example/myWebsite"},
+    "https://w3id.org/security/data-integrity/v2"
+  ],
+  "myWebsite": "https://hello.world.example/",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "created": "2020-06-11T19:14:04Z",
+    <span class="comment">// the proof expires a month after it was issued</span>
+    <span class="highlight">expires": "2020-07-11T19:14:04Z"</span>,
+    "verificationMethod": "https://ldi.example/issuer#zDnaepBuvsQ8cpsWrVK<wbr>w8fbpGpvPeNSjVPTWoq6cRqaYzBKVP",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z98X7RLrkjnXEADJNUhiTEdwyE5GXX8cyJZRLQZ7vZyUXb23Zkdakf<wbr>RJ7adYY8hn35EetqBkNw813SGsJHWrcpo4"
+  }
+}
+        </pre>
+
       <p>
 The Data Integrity specification supports the concept of multiple
 proofs in a single document. There are two types of multi-proof


### PR DESCRIPTION
This PR is an attempt to address issue #313 by adding a proof to the specification that uses the `expires` property. 

/cc @filip26


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/314.html" title="Last updated on Oct 14, 2024, 9:32 PM UTC (00e0119)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/314/25e2237...00e0119.html" title="Last updated on Oct 14, 2024, 9:32 PM UTC (00e0119)">Diff</a>