### PR TITLE
Remove "must" language in unlinkability section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3059,7 +3059,7 @@ correlatable tracking data while also providing some level of assurance that the
 payload is trustworthy for a given interaction. This characteristic is called
 <dfn class="lint-ignore">unlinkability</dfn> which ensures that no correlatable
 data are used in a digitally-signed payload while still providing some level of
-trust, the sufficiency of which must be determined by each verifier.
+trust, the sufficiency of which has to be determined by each verifier.
         </p>
 
         <p>


### PR DESCRIPTION
This PR addresses issue https://github.com/w3c/vc-data-integrity/issues/318.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/319.html" title="Last updated on Nov 11, 2024, 5:26 PM UTC (0b35792)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/319/0a824e8...Wind4Greg:0b35792.html" title="Last updated on Nov 11, 2024, 5:26 PM UTC (0b35792)">Diff</a>