### PR TITLE
Changing the references to the controller document to cid

### DIFF
--- a/vocab/security/vocabulary.drawio
+++ b/vocab/security/vocabulary.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.7.17 Chrome/128.0.6613.36 Electron/32.0.1 Safari/537.36" version="24.7.17">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/25.0.2 Chrome/128.0.6613.186 Electron/32.2.5 Safari/537.36" version="25.0.2">
   <diagram name="Page-1" id="hQ0IBVJ5jpEcegRt-_B3">
-    <mxGraphModel dx="1732" dy="2191" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+    <mxGraphModel dx="1732" dy="2127" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -632,12 +632,12 @@
             <mxPoint x="810" y="163.97000000000003" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;ControllerDocument&lt;/i&gt;" link="https://w3id.org/security#ControllerDocument" id="EKtz_mp9gxkMvZtS7m4M-1">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" vertex="1" parent="1">
-            <mxGeometry x="779.9981360201509" y="30" width="208.7336272040302" height="46.89083823529412" as="geometry" />
+        <UserObject label="&lt;i&gt;ControlledIdentifierDocument&lt;/i&gt;" link="https://w3id.org/security#ControlledIdentifierDocument" id="EKtz_mp9gxkMvZtS7m4M-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="770" y="30" width="230" height="46.89" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="EKtz_mp9gxkMvZtS7m4M-2" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" edge="1" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-44" target="EKtz_mp9gxkMvZtS7m4M-1">
+        <mxCell id="EKtz_mp9gxkMvZtS7m4M-2" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=1 1;" parent="1" source="Uf8WLKuzS3drS_BCJ-BJ-44" target="EKtz_mp9gxkMvZtS7m4M-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="919.5" y="179" as="sourcePoint" />
             <mxPoint x="1022.5" y="-10" as="targetPoint" />

--- a/vocab/security/vocabulary.svg
+++ b/vocab/security/vocabulary.svg
@@ -966,25 +966,25 @@
                 <path fill="none" stroke-dasharray="6 6" d="m1454.86 635.46-151.26-138" pointer-events="stroke"/>
                 <path fill="#009" d="m1298.06 492.4 10.76 3.05-5.22 2.01-1.52 5.37Z" pointer-events="all"/>
             </g>
-            <a xlink:href="https://w3id.org/security#ControllerDocument" data-cell-id="EKtz_mp9gxkMvZtS7m4M-1">
-                <ellipse cx="897.36" cy="474.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="104.367" ry="23.445"/>
+            <a xlink:href="https://w3id.org/security#ControlledIdentifierDocument" data-cell-id="EKtz_mp9gxkMvZtS7m4M-1">
+                <ellipse cx="898" cy="474.45" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="115" ry="23.445"/>
                 <switch transform="translate(-.5 -.5)">
                     <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:207px;height:1px;padding-top:474px;margin-left:794px">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:228px;height:1px;padding-top:474px;margin-left:784px">
                             <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                                 <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                                     <i>
-                                        ControllerDocument
+                                        ControlledIdentifierDocument
                                     </i>
                                 </div>
                             </div>
                         </div>
                     </foreignObject>
-                    <text xmlns="http://www.w3.org/2000/svg" x="897" y="479" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">ControllerDocument</text>
+                    <text xmlns="http://www.w3.org/2000/svg" x="898" y="479" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">ControlledIdentifierDocument</text>
                 </switch>
             </a>
             <g stroke="#c00" stroke-miterlimit="10" stroke-width="2" data-cell-id="EKtz_mp9gxkMvZtS7m4M-2">
-                <path fill="none" stroke-dasharray="2 2" d="M958.93 654.64Q913 551 897.36 497.89" pointer-events="stroke"/>
+                <path fill="none" stroke-dasharray="2 2" d="M958.93 654.64Q913 551 898 497.89" pointer-events="stroke"/>
                 <path fill="#c00" d="m961.96 661.49-8.62-7.11 5.59.26 3.55-4.32Z" pointer-events="all"/>
             </g>
         </g>

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -21,7 +21,7 @@ ontology:
 class:
   - id: ControllerDocument
     label: Controller document
-    defined_by: https://www.w3.org/TR/cid/#controller-documents
+    defined_by: https://www.w3.org/TR/cid-1.0/#controller-documents
 
   - id: Proof
     label: Digital proof
@@ -36,11 +36,11 @@ class:
   - id: VerificationMethod
     label: Verification method
     comment: Instances of this class must be <a href="https://www.w3.org/TR/rdf11-concepts/#resources-and-statements">denoted by URLs</a>, i.e., they cannot be blank nodes.
-    defined_by: https://www.w3.org/TR/cid/#verification-methods
+    defined_by: https://www.w3.org/TR/cid-1.0/#verification-methods
 
   - id: VerificationRelationship
     comment: Instances of this class are verification relationships like, for example, <a href="#authentication">authentication</a> or <a href="#assertionMethod">assertionMethod</a>. These resources can also appear as values of the <a href="#proofPurpose">proofPurpose</a> property.
-    defined_by: https://www.w3.org/TR/cid/#verification-relationships
+    defined_by: https://www.w3.org/TR/cid-1.0/#verification-relationships
     upper_value: rdf:Property
     context: none
 
@@ -53,7 +53,7 @@ class:
   - id: Multikey
     label: Multikey Verification Method
     upper_value: sec:VerificationMethod
-    defined_by: https://www.w3.org/TR/cid/#multikey
+    defined_by: https://www.w3.org/TR/cid-1.0/#multikey
     see_also:
       - label: EdDSA Cryptosuites
         url: https://www.w3.org/TR/vc-di-eddsa/#multikey
@@ -66,7 +66,7 @@ class:
   - id: JsonWebKey
     label: JSON Web Key Verification Method
     upper_value: sec:VerificationMethod
-    defined_by: https://www.w3.org/TR/cid/#jsonwebkey
+    defined_by: https://www.w3.org/TR/cid-1.0/#jsonwebkey
     context: https://w3id.org/security/jwk/v1
 
   - id: Ed25519VerificationKey2020
@@ -191,7 +191,7 @@ property:
   - id: verificationMethod
     label: Verification method
     range: sec:VerificationMethod
-    defined_by: https://www.w3.org/TR/cid/#dfn-verificationmethod
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-verificationmethod
     see_also:
       - label: Decentralized Identifiers (DIDs) v1.0
         url: https://www.w3.org/TR/did-core/#verification-methods
@@ -203,7 +203,7 @@ property:
       - sec:VerificationMethod
       - sec:ControllerDocument
     range: IRI
-    defined_by: https://www.w3.org/TR/cid/#defn-controller
+    defined_by: https://www.w3.org/TR/cid-1.0/#defn-controller
     context: [https://w3id.org/security/multikey/v1, https://w3id.org/security/jwk/v1, https://www.w3.org/ns/did/v1]
 
   - id: proof
@@ -255,7 +255,7 @@ property:
 
   - id: expiration
     label: Expiration time for a proof or verification method
-    defined_by: [https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires, https://www.w3.org/TR/cid/#defn-vm-expires]
+    defined_by: [https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires, https://www.w3.org/TR/cid-1.0/#defn-vm-expires]
     comment: Historically, this property has often been expressed using `expires` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`expires`) and the property identifier (`...#expiration`) is expected and should not trigger an error.
     domain:
       - sec:Proof
@@ -274,14 +274,14 @@ property:
     label: Authentication method
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
-    defined_by: https://www.w3.org/TR/cid/#authentication
+    defined_by: https://www.w3.org/TR/cid-1.0/#authentication
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: assertionMethod
     label: Assertion method
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
-    defined_by: https://www.w3.org/TR/cid/#assertion
+    defined_by: https://www.w3.org/TR/cid-1.0/#assertion
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: capabilityDelegationMethod
@@ -289,7 +289,7 @@ property:
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
     comment: Historically, this property has often been expressed using `capabilityDelegation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityDelegation`) and the property identifier (`...#capabilityDelegationMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/cid/#capability-delegation
+    defined_by: https://www.w3.org/TR/cid-1.0/#capability-delegation
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: capabilityInvocationMethod
@@ -297,7 +297,7 @@ property:
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
     comment: Historically, this property has often been expressed using `capabilityInvocation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityInvocation`) and the property identifier (`...#capabilityInvocationMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/cid/#capability-invocation
+    defined_by: https://www.w3.org/TR/cid-1.0/#capability-invocation
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: keyAgreementMethod
@@ -305,7 +305,7 @@ property:
     type: sec:VerificationRelationship
     range: sec:VerificationMethod
     comment: Historically, this property has often been expressed using `keyAgreement` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`keyAgreement`) and the property identifier (`...#keyAgreementMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/cid/#key-agreement
+    defined_by: https://www.w3.org/TR/cid-1.0/#key-agreement
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: cryptosuite
@@ -319,7 +319,7 @@ property:
     label: Public key multibase
     domain: sec:Multikey
     range: sec:multibase
-    defined_by: https://www.w3.org/TR/cid/#dfn-publickeymultibase
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-publickeymultibase
     see_also:
       - label: multibase
         url: https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03
@@ -331,7 +331,7 @@ property:
     label: Secret key multibase
     domain: sec:Multikey
     range: sec:multibase
-    defined_by: https://www.w3.org/TR/cid/#dfn-secretkeymultibase
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-secretkeymultibase
     see_also:
       - label: multibase format
         url: https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03
@@ -343,7 +343,7 @@ property:
     label: Public key JWK
     range: rdf:JSON
     domain: sec:JsonWebKey
-    defined_by: https://www.w3.org/TR/cid/#dfn-publickeyjwk
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-publickeyjwk
     see_also:
       - label: IANA JOSE
         url: https://www.iana.org/assignments/jose/jose.xhtml
@@ -355,7 +355,7 @@ property:
     label: Secret key JWK
     range: rdf:JSON
     domain: sec:JsonWebKey
-    defined_by: https://www.w3.org/TR/cid/#dfn-secretkeyjwk
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-secretkeyjwk
     see_also:
       - label: IANA JOSE
         url: https://www.iana.org/assignments/jose/jose.xhtml
@@ -366,7 +366,7 @@ property:
   - id: revoked
     label: Revocation time
     range: xsd:dateTime
-    defined_by: https://www.w3.org/TR/cid/#dfn-revoked
+    defined_by: https://www.w3.org/TR/cid-1.0/#dfn-revoked
     domain: sec:VerificationMethod
     context: https://w3id.org/security/jwk/v1
 
@@ -548,5 +548,5 @@ datatype:
   - id: multibase
     label: Datatype for multibase values
     upper_value: xsd:string
-    defined_by: https://www.w3.org/TR/cid/#multibase
+    defined_by: https://www.w3.org/TR/cid-1.0/#multibase
     context: https://w3id.org/security/multikey/v1

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -21,7 +21,7 @@ ontology:
 class:
   - id: ControllerDocument
     label: Controller document
-    defined_by: https://www.w3.org/TR/controller-document/#controller-documents
+    defined_by: https://www.w3.org/TR/cid/#controller-documents
 
   - id: Proof
     label: Digital proof
@@ -36,11 +36,11 @@ class:
   - id: VerificationMethod
     label: Verification method
     comment: Instances of this class must be <a href="https://www.w3.org/TR/rdf11-concepts/#resources-and-statements">denoted by URLs</a>, i.e., they cannot be blank nodes.
-    defined_by: https://www.w3.org/TR/controller-document/#verification-methods
+    defined_by: https://www.w3.org/TR/cid/#verification-methods
 
   - id: VerificationRelationship
     comment: Instances of this class are verification relationships like, for example, <a href="#authentication">authentication</a> or <a href="#assertionMethod">assertionMethod</a>. These resources can also appear as values of the <a href="#proofPurpose">proofPurpose</a> property.
-    defined_by: https://www.w3.org/TR/controller-document/#verification-relationships
+    defined_by: https://www.w3.org/TR/cid/#verification-relationships
     upper_value: rdf:Property
     context: none
 
@@ -53,7 +53,7 @@ class:
   - id: Multikey
     label: Multikey Verification Method
     upper_value: sec:VerificationMethod
-    defined_by: https://www.w3.org/TR/controller-document/#multikey
+    defined_by: https://www.w3.org/TR/cid/#multikey
     see_also:
       - label: EdDSA Cryptosuites
         url: https://www.w3.org/TR/vc-di-eddsa/#multikey
@@ -66,7 +66,7 @@ class:
   - id: JsonWebKey
     label: JSON Web Key Verification Method
     upper_value: sec:VerificationMethod
-    defined_by: https://www.w3.org/TR/controller-document/#jsonwebkey
+    defined_by: https://www.w3.org/TR/cid/#jsonwebkey
     context: https://w3id.org/security/jwk/v1
 
   - id: Ed25519VerificationKey2020
@@ -191,7 +191,7 @@ property:
   - id: verificationMethod
     label: Verification method
     range: sec:VerificationMethod
-    defined_by: https://www.w3.org/TR/controller-document/#dfn-verificationmethod
+    defined_by: https://www.w3.org/TR/cid/#dfn-verificationmethod
     see_also:
       - label: Decentralized Identifiers (DIDs) v1.0
         url: https://www.w3.org/TR/did-core/#verification-methods
@@ -203,7 +203,7 @@ property:
       - sec:VerificationMethod
       - sec:ControllerDocument
     range: IRI
-    defined_by: https://www.w3.org/TR/controller-document/#defn-controller
+    defined_by: https://www.w3.org/TR/cid/#defn-controller
     context: [https://w3id.org/security/multikey/v1, https://w3id.org/security/jwk/v1, https://www.w3.org/ns/did/v1]
 
   - id: proof
@@ -255,7 +255,7 @@ property:
 
   - id: expiration
     label: Expiration time for a proof or verification method
-    defined_by: [https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires, https://www.w3.org/TR/controller-document/#defn-vm-expires]
+    defined_by: [https://www.w3.org/TR/vc-data-integrity/#defn-proof-expires, https://www.w3.org/TR/cid/#defn-vm-expires]
     comment: Historically, this property has often been expressed using `expires` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`expires`) and the property identifier (`...#expiration`) is expected and should not trigger an error.
     domain:
       - sec:Proof
@@ -274,14 +274,14 @@ property:
     label: Authentication method
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
-    defined_by: https://www.w3.org/TR/controller-document/#authentication
+    defined_by: https://www.w3.org/TR/cid/#authentication
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: assertionMethod
     label: Assertion method
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
-    defined_by: https://www.w3.org/TR/controller-document/#assertion
+    defined_by: https://www.w3.org/TR/cid/#assertion
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: capabilityDelegationMethod
@@ -289,7 +289,7 @@ property:
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
     comment: Historically, this property has often been expressed using `capabilityDelegation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityDelegation`) and the property identifier (`...#capabilityDelegationMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/controller-document/#capability-delegation
+    defined_by: https://www.w3.org/TR/cid/#capability-delegation
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: capabilityInvocationMethod
@@ -297,7 +297,7 @@ property:
     range: sec:VerificationMethod
     type: sec:VerificationRelationship
     comment: Historically, this property has often been expressed using `capabilityInvocation` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`capabilityInvocation`) and the property identifier (`...#capabilityInvocationMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/controller-document/#capability-invocation
+    defined_by: https://www.w3.org/TR/cid/#capability-invocation
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: keyAgreementMethod
@@ -305,7 +305,7 @@ property:
     type: sec:VerificationRelationship
     range: sec:VerificationMethod
     comment: Historically, this property has often been expressed using `keyAgreement` as a shortened term in JSON-LD. Since this shortened term and its mapping to this property are in significant use in the ecosystem, the inconsistency between the short term name (`keyAgreement`) and the property identifier (`...#keyAgreementMethod`) is expected and should not trigger an error.
-    defined_by: https://www.w3.org/TR/controller-document/#key-agreement
+    defined_by: https://www.w3.org/TR/cid/#key-agreement
     context: [vocab, https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/did/v1]
 
   - id: cryptosuite
@@ -319,7 +319,7 @@ property:
     label: Public key multibase
     domain: sec:Multikey
     range: sec:multibase
-    defined_by: https://www.w3.org/TR/controller-document/#dfn-publickeymultibase
+    defined_by: https://www.w3.org/TR/cid/#dfn-publickeymultibase
     see_also:
       - label: multibase
         url: https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03
@@ -331,7 +331,7 @@ property:
     label: Secret key multibase
     domain: sec:Multikey
     range: sec:multibase
-    defined_by: https://www.w3.org/TR/controller-document/#dfn-secretkeymultibase
+    defined_by: https://www.w3.org/TR/cid/#dfn-secretkeymultibase
     see_also:
       - label: multibase format
         url: https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03
@@ -343,7 +343,7 @@ property:
     label: Public key JWK
     range: rdf:JSON
     domain: sec:JsonWebKey
-    defined_by: https://www.w3.org/TR/controller-document/#dfn-publickeyjwk
+    defined_by: https://www.w3.org/TR/cid/#dfn-publickeyjwk
     see_also:
       - label: IANA JOSE
         url: https://www.iana.org/assignments/jose/jose.xhtml
@@ -355,7 +355,7 @@ property:
     label: Secret key JWK
     range: rdf:JSON
     domain: sec:JsonWebKey
-    defined_by: https://www.w3.org/TR/controller-document/#dfn-secretkeyjwk
+    defined_by: https://www.w3.org/TR/cid/#dfn-secretkeyjwk
     see_also:
       - label: IANA JOSE
         url: https://www.iana.org/assignments/jose/jose.xhtml
@@ -366,7 +366,7 @@ property:
   - id: revoked
     label: Revocation time
     range: xsd:dateTime
-    defined_by: https://www.w3.org/TR/controller-document/#dfn-revoked
+    defined_by: https://www.w3.org/TR/cid/#dfn-revoked
     domain: sec:VerificationMethod
     context: https://w3id.org/security/jwk/v1
 
@@ -548,5 +548,5 @@ datatype:
   - id: multibase
     label: Datatype for multibase values
     upper_value: xsd:string
-    defined_by: https://www.w3.org/TR/controller-document/#multibase
+    defined_by: https://www.w3.org/TR/cid/#multibase
     context: https://w3id.org/security/multikey/v1

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -19,9 +19,9 @@ ontology:
     value: https://www.w3.org/TR/vc-data-integrity/
 
 class:
-  - id: ControllerDocument
-    label: Controller document
-    defined_by: https://www.w3.org/TR/cid-1.0/#controller-documents
+  - id: ControlledIdentifierDocument
+    label: Controlled Identifier Document
+    defined_by: https://www.w3.org/TR/cid-1.0/#controlled-identifier-documents
 
   - id: Proof
     label: Digital proof
@@ -201,7 +201,7 @@ property:
     label: Controller
     domain:
       - sec:VerificationMethod
-      - sec:ControllerDocument
+      - sec:ControlledIdentifierDocument
     range: IRI
     defined_by: https://www.w3.org/TR/cid-1.0/#defn-controller
     context: [https://w3id.org/security/multikey/v1, https://w3id.org/security/jwk/v1, https://www.w3.org/ns/did/v1]


### PR DESCRIPTION
Note that the outcome of https://github.com/w3c/cid/issues/132 is relevant here. If the decision is to change the concept, then the `ControllerDocument` class must be changed, too.

UPDATED:

In view of https://github.com/w3c/cid/issues/132 and https://github.com/w3c/cid/issues/134, the class name has also been changed to `ControlledIdentifierDocument` in https://github.com/w3c/vc-data-integrity/pull/325/commits/8e555e879e941e50fa191550a672eb5b9af8fbf6


