### PR TITLE
Remove the numerical error codes to be in sync with the VCDM specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -2366,7 +2366,7 @@ particular use case.
 The algorithms described in this specification, as well as in various cryptographic
 suite specifications, throw specific types of errors. Implementers might find
 it useful to convey these errors to other libraries or software systems. This
-section provides specific URLs, descriptions, and error codes for the errors,
+section provides specific URLs and descriptions for the errors,
 such that an ecosystem implementing technologies described by this
 specification might interoperate more effectively when errors occur.
         </p>
@@ -2384,38 +2384,34 @@ The `type` value of the error object MUST be a URL that starts with the value
 below.
           </li>
           <li>
-The `code` value MUST be the integer code described in the table below
-(in parentheses, beside the type name).
-          </li>
-          <li>
-The `title` value SHOULD provide a short but specific human-readable [=string=] for
+The `title` value MUST be present and SHOULD provide a short but specific human-readable [=string=] for
 the error.
           </li>
           <li>
-The `detail` value SHOULD provide a longer human-readable [=string=] for the error.
+The `detail` value MUST be present and SHOULD provide a longer human-readable [=string=] for the error.
           </li>
         </ul>
 
         <dl>
-          <dt id="PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR (-16)</dt>
+          <dt id="PROOF_GENERATION_ERROR">PROOF_GENERATION_ERROR</dt>
           <dd>
 A request to generate a proof failed. See Section [[[#add-proof]]], and Section
 [[[#add-proof-set-chain]]].
           </dd>
-          <dt id="PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR (-17)</dt>
+          <dt id="PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</dt>
           <dd>
 An error was encountered during proof verification. See Section [[[#verify-proof]]].
           </dd>
-          <dt id="PROOF_TRANSFORMATION_ERROR">PROOF_TRANSFORMATION_ERROR  (-18)</dt>
+          <dt id="PROOF_TRANSFORMATION_ERROR">PROOF_TRANSFORMATION_ERROR </dt>
           <dd>
 An error was encountered during the transformation process.
           </dd>
-          <dt id="INVALID_DOMAIN_ERROR">INVALID_DOMAIN_ERROR (-19)</dt>
+          <dt id="INVALID_DOMAIN_ERROR">INVALID_DOMAIN_ERROR</dt>
           <dd>
 The `domain` value in a proof did not match the expected value. See Section
 [[[#verify-proof]]].
           </dd>
-          <dt id="INVALID_CHALLENGE_ERROR">INVALID_CHALLENGE_ERROR (-20)</dt>
+          <dt id="INVALID_CHALLENGE_ERROR">INVALID_CHALLENGE_ERROR</dt>
           <dd>
 The `challenge` value in a proof did not match the expected value. See Section
 [[[#verify-proof]]].

--- a/index.html
+++ b/index.html
@@ -2388,7 +2388,7 @@ The `title` value SHOULD provide a short but specific human-readable [=string=] 
 the error.
           </li>
           <li>
-The `detail` value MUST be present and SHOULD provide a longer human-readable [=string=] for the error.
+The `detail` value SHOULD provide a longer human-readable [=string=] for the error.
           </li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -2384,7 +2384,7 @@ The `type` value of the error object MUST be a URL that starts with the value
 below.
           </li>
           <li>
-The `title` value MUST be present and SHOULD provide a short but specific human-readable [=string=] for
+The `title` value SHOULD provide a short but specific human-readable [=string=] for
 the error.
           </li>
           <li>

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -481,62 +481,62 @@ property:
 individual:
   - id: PROOF_GENERATION_ERROR
     type: sec:ProcessingError
-    label: Proof generation error (-16)
+    label: Proof generation error
     defined_by: https://www.w3.org/TR/vc-data-integrity/#PROOF_GENERATION_ERROR
     context: none
 
   - id: PROOF_VERIFICATION_ERROR
     type: sec:ProcessingError
-    label: Malformed proof (-17)
+    label: Malformed proof
     defined_by: https://www.w3.org/TR/vc-data-integrity/#PROOF_VERIFICATION_ERROR
     context: none
 
   - id: PROOF_TRANSFORMATION_ERROR
     type: sec:ProcessingError
-    label: Mismatched proof purpose (-18)
+    label: Mismatched proof purpose
     defined_by: https://www.w3.org/TR/vc-data-integrity/#PROOF_TRANSFORMATION_ERROR
     context: none
 
   - id: INVALID_DOMAIN_ERROR
     type: sec:ProcessingError
-    label: Invalid proof domain (-19)
+    label: Invalid proof domain
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_DOMAIN_ERROR
     context: none
 
   - id: INVALID_CHALLENGE_ERROR
     type: sec:ProcessingError
-    label: Invalid challenge (-20)
+    label: Invalid challenge
     defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CHALLENGE_ERROR
     context: none
 
   - id: INVALID_VERIFICATION_METHOD_URL
     type: sec:ProcessingError
-    label: Invalid verification method URL (-21)
-    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD_URL
+    label: Invalid verification method URL
+    defined_by: https://www.w3.org/TR/controller-document/#INVALID_VERIFICATION_METHOD_URL
     context: none
 
-  - id: INVALID_CONTROLLER_DOCUMENT_ID
+  - id: INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID
     type: sec:ProcessingError
-    label: Invalid controller document id (-22)
-    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CONTROLLER_DOCUMENT_ID
+    label: Invalid controlled identifier document id
+    defined_by: https://www.w3.org/TR/controller-document/#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID
     context: none
 
-  - id: INVALID_CONTROLLER_DOCUMENT
+  - id: INVALID_CONTROLLED_IDENTIFIER_DOCUMENT
     type: sec:ProcessingError
-    label: Invalid controller document (-23)
-    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_CONTROLLER_DOCUMENT
+    label: Invalid controlled identifier document
+    defined_by: https://www.w3.org/TR/controller-document/#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT
     context: none
 
   - id: INVALID_VERIFICATION_METHOD
     type: sec:ProcessingError
-    label: Invalid verification method (-24)
-    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_VERIFICATION_METHOD
+    label: Invalid verification method
+    defined_by: https://www.w3.org/TR/controller-document/#INVALID_VERIFICATION_METHOD
     context: none
 
-  - id: INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD
+  - id: INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD
     type: sec:ProcessingError
-    label: Invalid proof purpose for verification method (-25)
-    defined_by: https://www.w3.org/TR/vc-data-integrity/#INVALID_PROOF_PURPOSE_FOR_VERIFICATION_METHOD
+    label: Invalid relationship for verification method
+    defined_by: https://www.w3.org/TR/controller-document/#INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD
     context: none
 
 datatype:

--- a/vocab/security/vocabulary.yml
+++ b/vocab/security/vocabulary.yml
@@ -512,31 +512,31 @@ individual:
   - id: INVALID_VERIFICATION_METHOD_URL
     type: sec:ProcessingError
     label: Invalid verification method URL
-    defined_by: https://www.w3.org/TR/controller-document/#INVALID_VERIFICATION_METHOD_URL
+    defined_by: https://www.w3.org/TR/cid-1.0/#INVALID_VERIFICATION_METHOD_URL
     context: none
 
   - id: INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID
     type: sec:ProcessingError
     label: Invalid controlled identifier document id
-    defined_by: https://www.w3.org/TR/controller-document/#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID
+    defined_by: https://www.w3.org/TR/cid-1.0/#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT_ID
     context: none
 
   - id: INVALID_CONTROLLED_IDENTIFIER_DOCUMENT
     type: sec:ProcessingError
     label: Invalid controlled identifier document
-    defined_by: https://www.w3.org/TR/controller-document/#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT
+    defined_by: https://www.w3.org/TR/cid-1.0/#INVALID_CONTROLLED_IDENTIFIER_DOCUMENT
     context: none
 
   - id: INVALID_VERIFICATION_METHOD
     type: sec:ProcessingError
     label: Invalid verification method
-    defined_by: https://www.w3.org/TR/controller-document/#INVALID_VERIFICATION_METHOD
+    defined_by: https://www.w3.org/TR/cid-1.0/#INVALID_VERIFICATION_METHOD
     context: none
 
   - id: INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD
     type: sec:ProcessingError
     label: Invalid relationship for verification method
-    defined_by: https://www.w3.org/TR/controller-document/#INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD
+    defined_by: https://www.w3.org/TR/cid-1.0/#INVALID_RELATIONSHIP_FOR_VERIFICATION_METHOD
     context: none
 
 datatype:


### PR DESCRIPTION
Following up on https://github.com/w3c/cid/pull/134#discussion_r1884295424: 

- Removed the error codes from the processing errors (both in the spec and in the vocabulary). I have also synched with the corresponding VCDM spec which _require_ some terms in the error.
- In the vocabulary, the links to the controller document was still present for the error code; I have changed that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/327.html" title="Last updated on Jan 20, 2025, 7:11 AM UTC (13b9a61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/327/5b24b45...13b9a61.html" title="Last updated on Jan 20, 2025, 7:11 AM UTC (13b9a61)">Diff</a>