### PR TITLE
Add security considerations section on safer abstractions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2680,32 +2680,31 @@ easy to use for developers.
         <h3>Safer Abstractions</h3>
 
         <p>
-A [=proof=] contains a `proofValue`, which itself can embed a number of
-parameters related to a cryptographic proof. For example,
+A [=proof=] contains a `proofValue`, in which a number of parameters
+related to a cryptographic proof can be embedded. For example,
 the selective disclosure algorithms in the [[[?VC-DI-ECDSA]]] specification
-include multiple cryptographic signatures in the `proofValue` for every
-item that is selectively disclosed. This has been done to make the
+include multiple cryptographic signatures in the `proofValue`, one for every
+item that is selectively disclosable. This has been done to make the
 technology easier and safer to use by application developers.
         </p>
 
         <p>
-For information that is rarely needed by the application layer, this
-specification urges specification authors to abstract that information into a
-single value. Much like a `data:` URL expressing an image encapsulates many of
-the image rendering parameters into a single value, the `proofValue` property
-(and other similar properties) abstracts information that is not useful to an
-application developer in order to simplify identification of fields that are of
-importance to the application. Abstracting information in this way leads to a
-data structure that is easier for developers to work with as well as one that is
-less susceptible to being corrupted by a programming mistake that accidentally
-adds or removes a critical property that could negatively impact the
-cryptographic layer.
+This specification urges specification authors to use a single value to abstract
+information that is rarely needed by the application layer. Much like a `data:`
+URL expressing an image encapsulates many of the image rendering parameters into
+a single value, the `proofValue` property (and other similar properties)
+abstracts information that is not useful to an application developer in order to
+simplify identification of fields that <em>are</em> important to the application.
+Abstracting information in this way leads to a data structure that is easier for
+developers to work with while being less susceptible to, for instance, accidental
+corruption due to a programming error that adds or removes a critical property,
+negatively impacting the cryptographic layer.
         </p>
 
         <p>
-The design of data integrity is such that information that is generally only
-useful to the cryptographic layer is abstracted into a single property to ease
-the burden on application developers and enhance the security of the system.
+The design of data integrity in this specification abstracts information that is
+generally only useful to the cryptographic layer into a single property to ease
+the burden on application developers and to enhance the security of the system.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2677,6 +2677,39 @@ easy to use for developers.
       </section>
 
       <section>
+        <h3>Safer Abstractions</h3>
+
+        <p>
+A [=proof=] contains a `proofValue`, which itself can embed a number of
+parameters related to a cryptographic proof. For example,
+the selective disclosure algorithms in the [[[?VC-DI-ECDSA]]] specification
+include multiple cryptographic signatures in the `proofValue` for every
+item that is selectively disclosed. This has been done to make the
+technology easier and safer to use by application developers.
+        </p>
+
+        <p>
+For information that is rarely needed by the application layer, this
+specification urges specification authors to abstract that information into a
+single value. Much like a `data:` URL expressing an image encapsulates many of
+the image rendering parameters into a single value, the `proofValue` property
+(and other similar properties) abstracts information that is not useful to an
+application developer in order to simplify identification of fields that are of
+importance to the application. Abstracting information in this way leads to a
+data structure that is easier for developers to work with as well as one that is
+less susceptible to being corrupted by a programming mistake that accidentally
+adds or removes a critical property that could negatively impact the
+cryptographic layer.
+        </p>
+
+        <p>
+The design of data integrity is such that information that is generally only
+useful to the cryptographic layer is abstracted into a single property to ease
+the burden on application developers and enhance the security of the system.
+        </p>
+      </section>
+
+      <section>
         <h3>Transformations</h3>
 
         <p>


### PR DESCRIPTION
This PR is an attempt to address issue #329 by explaining why we roll up multiple cryptographic parameters into a single value.

/cc @jeswr


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/330.html" title="Last updated on Jan 26, 2025, 5:41 PM UTC (02e7c56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/330/2b27882...02e7c56.html" title="Last updated on Jan 26, 2025, 5:41 PM UTC (02e7c56)">Diff</a>