### PR TITLE
Appendix on Proof Sets/Chains: Clarity improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3330,9 +3330,9 @@ a document. We denote the secret/public keys of each of these signatories by
 <em>secretVPE/publicVPE</em>, respectively.
       </p>
       <p>
-When multiple signatories intend to sign an |inputDocument| and the ordering of
-those signatures are not of concern and there are no dependencies amongst the
-signatures then a [=proof set=] is typically a more straight forward
+When multiple signatories intend to sign an |inputDocument|, the ordering of
+those signatures is not of concern, and there are no dependencies amongst the
+signatures, then a [=proof set=] is typically a more straightforward
 construction.
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -3330,8 +3330,13 @@ a document. We denote the secret/public keys of each of these signatories by
 <em>secretVPE/publicVPE</em>, respectively.
       </p>
       <p>
-When constructing a [=proof set=] where each of the signatories signs an
-|inputDocument| without concern, we construct a proof symbolically as:
+When multiple signatories intend to sign an |inputDocument| and the ordering of
+those signatures are not of concern and there are no dependencies amongst the
+signatures then a [=proof set=] is typically a more straight forward
+construction.
+      </p>
+      <p>
+We construct a proof symbolically as:
       </p>
       <pre class="example nohighlight" title="Symbolic expression of how a proof is created">
 {

--- a/index.html
+++ b/index.html
@@ -3330,7 +3330,7 @@ a document. We denote the secret/public keys of each of these signatories by
 <em>secretVPE/publicVPE</em>, respectively.
       </p>
       <p>
-When multiple signatories intend to sign an |inputDocument|, the ordering of
+If multiple signatories intend to sign an |inputDocument|, the ordering of
 those signatures is not of concern, and there are no dependencies amongst the
 signatures, then a [=proof set=] is typically a more straightforward
 construction.


### PR DESCRIPTION
Editorial only. Informative Appendix. Fix wording to add missing explanatory text. It looks like some text got chopped on in the explanation of proof sets. This PR provides a fix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Wind4Greg/vc-data-integrity/pull/335.html" title="Last updated on Feb 20, 2025, 6:15 PM UTC (302ead6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/335/ad1e510...Wind4Greg:302ead6.html" title="Last updated on Feb 20, 2025, 6:15 PM UTC (302ead6)">Diff</a>