### PR TITLE
Attempts to get rid of the js issues

### DIFF
--- a/common.js
+++ b/common.js
@@ -133,29 +133,29 @@ var vcwg = {
     }
   }
 };
-require(["core/pubsubhub"], (respecEvents) => {
-  "use strict";
+// require(["core/pubsubhub"], (respecEvents) => {
+//   "use strict";
 
-  console.log("RESPEC EVENTS", respecEvents);
+//   console.log("RESPEC EVENTS", respecEvents);
 
-  respecEvents.sub('end-all', (message) => {
-    console.log("END EVENT", message);
-    // remove data-cite on where the citation is to ourselves.
-    const selfDfns = document.querySelectorAll("dfn[data-cite^='" + respecConfig.shortName.toUpperCase() + "#']");
-    for (const dfn of selfDfns) {
-      delete dfn.dataset.cite;
-    }
+//   respecEvents.sub('end-all', (message) => {
+//     console.log("END EVENT", message);
+//     // remove data-cite on where the citation is to ourselves.
+//     const selfDfns = document.querySelectorAll("dfn[data-cite^='" + respecConfig.shortName.toUpperCase() + "#']");
+//     for (const dfn of selfDfns) {
+//       delete dfn.dataset.cite;
+//     }
 
-    // Update data-cite references to ourselves.
-    const selfRefs = document.querySelectorAll("a[data-cite^='" + respecConfig.shortName.toUpperCase() + "#']");
-    for (const anchor of selfRefs) {
-      anchor.href= anchor.dataset.cite.replace(/^.*#/,"#");
-      delete anchor.dataset.cite;
-    }
+//     // Update data-cite references to ourselves.
+//     const selfRefs = document.querySelectorAll("a[data-cite^='" + respecConfig.shortName.toUpperCase() + "#']");
+//     for (const anchor of selfRefs) {
+//       anchor.href= anchor.dataset.cite.replace(/^.*#/,"#");
+//       delete anchor.dataset.cite;
+//     }
 
-  });
+//   });
 
-});
+// });
 
 // Removes dfns that aren't referenced anywhere in the spec.
 // To ensure a definition appears in the Terminology section, use

--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
       For the three scripts below, if your spec resides on dev.w3 you can check them
       out in the same tree and use relative links so that they'll work offline,
      -->
-    <script src='//www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
+    <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script class='remove' src="./common.js"></script>
     <script class="remove"
-      src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@3.4.2/dist/main.js"></script>
+      src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@3.5.2/dist/main.js"></script>
 
     <script type="text/javascript" class="remove">
       var respecConfig = {
@@ -224,6 +224,7 @@
             }
           },
           postProcess: [
+            restrictRefs,
             window.respecVc.createVcExamples
           ],
           lint: {


### PR DESCRIPTION
The browser console contains some issues, which may be the reason why echidna does not complete

This is an attempt to get rid of things. I have looked at the vcdm spec (which does not have this issues) and synched from there.

I have

- commented out from common.js the `require(["core/pubsubhub"]…` from in the code, but I added `restrictRefs` to post process (like in VCDM). I suspect respec "outdated" the `pubsubhub` mechanism sometimes last year...
- to be on the safe side I upgraded the respec-vc reference to the latest one

This made the require error disappear (of course) and I did not see any difference in the generated HTML (I am not sure why that code was there in the first place...) but @msporny should know.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/364.html" title="Last updated on Aug 29, 2026, 5:58 AM UTC (d85d8df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/364/c08b375...d85d8df.html" title="Last updated on Aug 29, 2026, 5:58 AM UTC (d85d8df)">Diff</a>