### PR TITLE
Update to define the SIC proof header bytes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3602,10 +3602,8 @@ private key associated with the base proof verification method.
             </li>
 
             <li>
-If |cryptosuite| is set to `ecdsa-sd-2023` then
-initialize a byte array, |proofBytes|, so that starts with the legacay
-ECDSA-SD base proof header bytes 0xd9, 0x5d, and 0x00. Otherwise initialize
-|proofValue| with the general SIC header bytes TBD.
+Initialize a byte array, |proofBytes|, so that starts with the SIC approach
+base proof header bytes 0xd9, 0x5d, and 0x00.
             </li>
             <li>
 Initialize |components| to an array with five elements containing the values of:
@@ -3646,9 +3644,8 @@ substring after the leading `u` in |proofValue|.
             </li>
             <li>
 
-If the |decodedProofValue| does not start with the ECDSA-SD base proof
-header bytes `0xd9`, `0x5d`, and `0x00`, or the general SIC header bytes TBD,
-an error MUST be raised and SHOULD
+If the |decodedProofValue| does not start with the general SIC header bytes
+header bytes `0xd9`, `0x5d`, and `0x00`, an error MUST be raised and SHOULD
 convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>
@@ -3686,11 +3683,8 @@ Initialize |compressedLabelMap| to the result of calling the algorithm in
 Section [[[#compresslabelmap]]], passing |labelMap| as the parameter.
             </li>
             <li>
-If |cryptosuite| is set to `ecdsa-sd-2023` then
-initialize a byte array, |proofValue|, that starts with the ECDSA-SD disclosure
-proof header bytes `0xd9`, `0x5d`, and `0x01`. Otherwise initialize a byte
-array, |proofValue|, that starts with the general SIC derived proof header bytes
-TBD.
+Initialize a byte array, |proofValue|, that starts with the general SIC derived
+proof header bytes `0xd9`, `0x5d`, and `0x01`.
             </li>
             <li>
 Initialize |components| to an array with five elements containing the values of:
@@ -3735,9 +3729,8 @@ Initialize |decodedProofValue| to the result of base64url-no-pad-decoding the
 substring after the leading `u` in |proofValue|.
             </li>
             <li>
-If the |decodedProofValue| does not start with the ECDSA-SD disclosure proof
-header bytes `0xd9`, `0x5d`, and `0x01`, or the general SIC approach derived
-proof header bytes TBD, an error MUST be raised
+If the |decodedProofValue| does not start with the general SIC approach derived
+proof header bytes `0xd9`, `0x5d`, and `0x01`, an error MUST be raised
 and SHOULD convey an error type of
 <a data-cite="VC-DATA-INTEGRITY#PROOF_VERIFICATION_ERROR">PROOF_VERIFICATION_ERROR</a>.
             </li>


### PR DESCRIPTION
This PR updates the specification to defined the SIC (signed individual clams selective disclosure approach) to be the same *proof header bytes* as the ECDSA-SD. Note that ECDSA-SD was the template for the general SIC approach. This has no  impact on  ECDSA-SD functionality.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/pull/365.html" title="Last updated on Sep 8, 2026, 6:35 PM UTC (8be9a16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-integrity/365/57d0a5a...8be9a16.html" title="Last updated on Sep 8, 2026, 6:35 PM UTC (8be9a16)">Diff</a>